### PR TITLE
feat (android): add support to Instagram Stories video sharing

### DIFF
--- a/android/src/main/java/cl/json/social/ShareIntent.java
+++ b/android/src/main/java/cl/json/social/ShareIntent.java
@@ -140,6 +140,20 @@ public abstract class ShareIntent {
             if (ShareIntent.hasValidKey("method", options)) {
                 String method = options.getString("method");
                 switch (method) {
+                    case "shareBackgroundVideo": {
+                        if (ShareIntent.hasValidKey("backgroundVideo", options)) {
+                            this.backgroundAsset = new ShareFile(options.getString("backgroundVideo"), "background", this.reactContext);
+                            this.getIntent().setDataAndType(backgroundAsset.getURI(), backgroundAsset.getType());
+                            this.getIntent().addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+
+                            if (ShareIntent.hasValidKey("attributionURL", options)) {
+                                this.getIntent().putExtra("content_url", options.getString("attributionURL"));
+                            }
+                        } else {
+                            throw new java.lang.IllegalArgumentException("backgroundVideo is empty");
+                        }
+                        break;
+                    }
                     case "shareBackgroundImage": {
                         if (ShareIntent.hasValidKey("backgroundImage", options)) {
                             this.backgroundAsset = new ShareFile(options.getString("backgroundImage"), "background", this.reactContext);


### PR DESCRIPTION
# Overview
Background video assets currently is only available for iOS, this PR aims to add support for Android as well.

- Fixes #907 

# Test Plan
<details>

<summary>Minimal example</summary>

```js
import React from 'react';
import {StyleSheet, View, Button} from 'react-native';

import RNFetchBlob from 'rn-fetch-blob';
import Share from 'react-native-share';

const App = () => {
  const share = async () => {
    try {
      const cache = await RNFetchBlob.config({
        fileCache: true,
        appendExt: 'mp4',
      }).fetch('GET', 'https://www.w3schools.com/html/mov_bbb.mp4');

      await Share.shareSingle({
        social: Share.Social.INSTAGRAM_STORIES,
        method: Share.InstagramStories.SHARE_BACKGROUND_VIDEO,
        backgroundVideo: `file://${cache.path()}`,
      });
    } catch (error) {
      console.error(error);
    }
  };

  return (
    <View style={styles.container}>
      <Button title="Share Video" onPress={share} />
    </View>
  );
};

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
  },
});

export default App;
```
</details>

### Example

https://user-images.githubusercontent.com/11046907/102808928-082b5380-43b9-11eb-84de-34b7d68b1dab.mp4


