### PR TITLE
Make appId optional in Options type

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ type Options = {
   failOnCancel?: boolean,
   showAppsToView?: boolean,
   saveToFiles?: boolean,
-  appId: string,
+  appId?: string,
 };
 type MultipleOptions = {
   url?: string,


### PR DESCRIPTION
The `appId` option isn't mentioned in the [docs](https://react-native-share.github.io/react-native-share/docs/share-open/#supported-options) but is marked as mandatory in the Options flow type which breaks flow type checking.