### PR TITLE
fix: resolve promise on ios every time

### DIFF
--- a/ios/RNShare.m
+++ b/ios/RNShare.m
@@ -266,7 +266,7 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options
         if (activityError) {
             [controller  dismissViewControllerAnimated:true completion:nil];
             failureCallback(activityError);
-        } else if (completed || activityType == nil) {
+        } else {
             successCallback(@[@(completed), RCTNullIfNil(activityType)]);
         }
     };


### PR DESCRIPTION
# Overview
The `Share.open` promise doesn't resolve in some situations on iOS. For example when you cancel printing. It's well described in #865. This PR fixes that.

Fix #865 #857


# Test Plan

Please check #865, there are steps for reproduce and it should work as expected with this fix.
