### PR TITLE
Mark OpenReturn and ShareSingleReturn flow types as inexact

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,8 +156,8 @@ type ActivityItemSource = {
   linkMetadata?: LinkMetadata,
 };
 
-type OpenReturn = { app?: string, dismissedAction?: boolean };
-type ShareSingleReturn = { message: string, isInstalled?: boolean };
+type OpenReturn = { app?: string, dismissedAction?: boolean, ... };
+type ShareSingleReturn = { message: string, isInstalled?: boolean, ... };
 
 const requireAndAskPermissions = async (options: Options | MultipleOptions): Promise<any> => {
   if ((options.url || options.urls) && Platform.OS === 'android') {


### PR DESCRIPTION
With `exact_by_default=true` we get flow errors because `OpenReturn` and `ShareSingleReturn` are implicitly inexact. This PR marks them explicitly inexact.
