### PR TITLE
Android: fix sharing a single file

### DIFF
--- a/android/src/main/java/cl/json/social/ShareIntent.java
+++ b/android/src/main/java/cl/json/social/ShareIntent.java
@@ -252,7 +252,7 @@ public abstract class ShareIntent {
             this.fileShare = getFileShare(options);
             if (this.fileShare.isFile()) {
                 Uri uriFile = this.fileShare.getURI();
-                this.getIntent().setDataAndType(uriFile, this.fileShare.getType());
+                this.getIntent().setType(this.fileShare.getType());
                 this.getIntent().putExtra(Intent.EXTRA_STREAM, uriFile);
                 this.getIntent().addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
                 if (!TextUtils.isEmpty(message)) {


### PR DESCRIPTION
This is a follow-up to my previous PR https://github.com/react-native-share/react-native-share/pull/968 - looks like I have introduced a bug there.
According to the [official dev guide](https://developer.android.com/training/sharing/send.html#send-binary-content) we only need to set the type, and the URI goes to `EXTRA_STREAM`.

Without this change if I share a file to, say Gmail, I get a new email with the subject containing the URI which is clearly wrong. After the fix, as expected, I get a new email with the file attached.

Fixes https://github.com/react-native-share/react-native-share/issues/976