### PR TITLE
"If the Share dialog is opened from a Modal, even Modal is getting dismissed when we close share dialog" - Issue Fix

### DIFF
--- a/ios/RNShare.m
+++ b/ios/RNShare.m
@@ -267,7 +267,13 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options
         
         // always dismiss since this may be called from cancelled shares
         // but the share menu would remain open, and our callback would fire again on close
-        [controller dismissViewControllerAnimated:true completion:nil];
+        if(weakShareController){
+            // closing activity view controller
+            [weakShareController dismissViewControllerAnimated:true completion:nil];
+        } else {
+            [controller dismissViewControllerAnimated:true completion:nil];
+        }
+
         
         if (activityError) {
             failureCallback(activityError);


### PR DESCRIPTION
# Overview

This PR fixes for https://github.com/react-native-share/react-native-share/issues/981 "If the Share dialog is opened from a Modal, even Modal is getting dismissed when we close share dialog". 

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
