### PR TITLE
Added a quick summary of the open() and shareSingle() methods to docs

### DIFF
--- a/website/docs/share-open.mdx
+++ b/website/docs/share-open.mdx
@@ -3,6 +3,8 @@ id: share-open
 title: Share.open
 ---
 
+The open() method allows a user to share a premade message via a social medium they choose. In other words, code specifies the message that will be sent and the user chooses to whom and the social medium through which the message will be sent. This shared message may contain text, one or more files, or both.
+
 Calling this method will return a promise that will fulfill or be rejected as soon as ther user successfully open the share action sheet or cancel/fail. Because of that, you will need to handle the rejection while necessary.
 
 Using a promise implementation:

--- a/website/docs/share-single.mdx
+++ b/website/docs/share-single.mdx
@@ -3,6 +3,8 @@ id: share-single
 title: Share.shareSingle
 ---
 
+The shareSingle() method allows a user to share a premade message via a single prechosen social medium. In other words, code specifies both the message that will be sent and the social medium via which the message will be sent. The user chooses only to whom the message is sent. This shared message may contain text, one or more files, or both.
+
 Open the share dialog with the specific application. This returns a promise similar to `Share.open`, keep in mind that you will need to handle the same response when the user cancel/dismiss.
 
 Using a promise implementation:

--- a/website/docs/share-single.mdx
+++ b/website/docs/share-single.mdx
@@ -3,7 +3,7 @@ id: share-single
 title: Share.shareSingle
 ---
 
-The shareSingle() method allows a user to share a premade message via a single prechosen social medium. In other words, code specifies both the message that will be sent and the social medium via which the message will be sent. The user chooses only to whom the message is sent. This shared message may contain text, one or more files, or both.
+The shareSingle() method allows a user to share a premade message via a single prechosen social medium. In other words, code specifies both the message that will be sent and the social medium through which the message will be sent. The user chooses only to whom the message is sent. This shared message may contain text, one or more files, or both.
 
 Open the share dialog with the specific application. This returns a promise similar to `Share.open`, keep in mind that you will need to handle the same response when the user cancel/dismiss.
 


### PR DESCRIPTION
As someone who is new to the library, I struggled to understand what the open() and shareSingle() methods do and the difference between them. I think adding these short descriptions to the docs may help others in the same position.