### PR TITLE
fix(whatsapp): fix iOS Whatsapp images share

### DIFF
--- a/ios/WhatsAppShare.m
+++ b/ios/WhatsAppShare.m
@@ -14,14 +14,14 @@ RCT_EXPORT_MODULE();
 - (void)shareSingle:(NSDictionary *)options
     failureCallback:(RCTResponseErrorBlock)failureCallback
     successCallback:(RCTResponseSenderBlock)successCallback {
-
+    
     NSLog(@"Try open view");
-
+    
     if ([options objectForKey:@"message"] && [options objectForKey:@"message"] != [NSNull null]) {
         NSString *text = [RCTConvert NSString:options[@"message"]];
         text = [text stringByAppendingString: [@" " stringByAppendingString: options[@"url"]] ];
         NSString *whatsAppNumber = [RCTConvert NSString:options[@"whatsAppNumber"]];
-
+        
         if ([[UIApplication sharedApplication] canOpenURL: [NSURL URLWithString:@"whatsapp://app"]]) {
             NSLog(@"WhatsApp installed");
         } else {
@@ -29,30 +29,60 @@ RCT_EXPORT_MODULE();
             NSString *stringURL = @"http://itunes.apple.com/app/whatsapp-messenger/id310633997";
             NSURL *url = [NSURL URLWithString:stringURL];
             [[UIApplication sharedApplication] openURL:url];
-
+            
             NSString *errorMessage = @"Not installed";
             NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};
             NSError *error = [NSError errorWithDomain:@"com.rnshare" code:1 userInfo:userInfo];
-
+            
             NSLog(@"%@", errorMessage);
             return failureCallback(error);
         }
-
-        if ([options[@"url"] rangeOfString:@"wam"].location != NSNotFound || [options[@"url"] rangeOfString:@"mp4"].location != NSNotFound) {
+        
+        if ([options[@"url"] rangeOfString:@".wam"].location != NSNotFound || [options[@"url"] rangeOfString:@".mp4"].location != NSNotFound) {
             NSLog(@"Sending whatsapp movie");
             documentInteractionController = [UIDocumentInteractionController interactionControllerWithURL:[NSURL fileURLWithPath:options[@"url"]]];
             documentInteractionController.UTI = @"net.whatsapp.movie";
             documentInteractionController.delegate = self;
-
-            [documentInteractionController presentOpenInMenuFromRect:CGRectMake(0, 0, 0, 0) inView:[[[[[UIApplication sharedApplication] delegate] window] rootViewController] view] animated:YES];
+            
+            [documentInteractionController presentOpenInMenuFromRect:CGRectZero inView:[[[[[UIApplication sharedApplication] delegate] window] rootViewController] view] animated:YES];
             NSLog(@"Done whatsapp movie");
             successCallback(@[]);
+        } else if ([options[@"url"] rangeOfString:@"png"].location != NSNotFound || [options[@"url"] rangeOfString:@"jpeg"].location != NSNotFound || [options[@"url"] rangeOfString:@"jpg"].location != NSNotFound || [options[@"url"] rangeOfString:@"gif"].location != NSNotFound) {
+            UIImage * image;
+            NSURL *imageURL = [RCTConvert NSURL:options[@"url"]];
+            if (imageURL) {
+                if (imageURL.fileURL || [imageURL.scheme.lowercaseString isEqualToString:@"data"]) {
+                    NSError *error;
+                    NSData *data = [NSData dataWithContentsOfURL:imageURL
+                                                         options:(NSDataReadingOptions)0
+                                                           error:&error];
+                    if (!data) {
+                        NSError *error = [NSError errorWithDomain:@"com.rnshare" code:2 userInfo:@{ NSLocalizedDescriptionKey:@"Something went wrong"}];
+                        return failureCallback(error);
+                    }
+                    image = [UIImage imageWithData: data];
+                    NSString * documentsPath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0];
+                    NSString * filePath = [documentsPath stringByAppendingPathComponent:@"/whatsAppTmp.wai"];
+                    
+                    [UIImageJPEGRepresentation(image, 1.0) writeToFile:filePath atomically:YES];
+                    
+                    documentInteractionController = [UIDocumentInteractionController interactionControllerWithURL:[NSURL fileURLWithPath:filePath]];
+                    documentInteractionController.UTI = @"net.whatsapp.image";
+                    documentInteractionController.delegate = self;
+                    
+                    [documentInteractionController presentOpenInMenuFromRect:CGRectZero inView:[[[[[UIApplication sharedApplication] delegate] window] rootViewController] view] animated:YES];
+                    successCallback(@[]);
+                }
+            } else {
+                NSError *error = [NSError errorWithDomain:@"com.rnshare" code:3 userInfo:@{ NSLocalizedDescriptionKey:@"Something went wrong"}];
+                return failureCallback(error);
+            }
         } else {
             text = (NSString*)CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(NULL,(CFStringRef) text, NULL,CFSTR("!*'();:@&=+$,/?%#[]"),kCFStringEncodingUTF8));
             
             NSString * urlWhats = whatsAppNumber ? [NSString stringWithFormat:@"whatsapp://send?phone=%@&text=%@", whatsAppNumber, text] : [NSString stringWithFormat:@"whatsapp://send?text=%@", text];
             NSURL * whatsappURL = [NSURL URLWithString:urlWhats];
-    
+            
             if ([[UIApplication sharedApplication] canOpenURL: whatsappURL]) {
                 [[UIApplication sharedApplication] openURL: whatsappURL];
                 successCallback(@[]);


### PR DESCRIPTION
# Overview

This PR fix bug [#603](https://github.com/react-native-share/react-native-share/issues/603). With this implementation the _Share.shareSingle_ method will share an Image with Whatsapp.

As described in iOS [Whatsapp Documentation](https://faq.whatsapp.com/iphone/how-to-link-to-whatsapp-from-a-different-app/?lang=en) is not possible to share an image with Custom URL and text with image at the same time with Document Interaction API.

# Test Plan
1. Install Whatsapp on iOS device and verify the account.
2. Open your app
3. Invoke the _Share.shareSingle_ method with these options
```
{
  title: "title",
  subject: "subject",
  url: data:image/jpeg;base64,${base64},
  social: Share.Social.WHATSAPP,
  message: "message"
}
```
4. iOS Document Interaction will open;
5. Choose Whatsapp;
6. A preview of image will open on whatsapp;
7. Click done to share the image to a contact;
