### PR TITLE
fix(android): prevent implicit PendingIntent vulnerability

### DIFF
--- a/android/src/main/java/cl/json/social/TargetChosenReceiver.java
+++ b/android/src/main/java/cl/json/social/TargetChosenReceiver.java
@@ -51,6 +51,7 @@ public class TargetChosenReceiver extends BroadcastReceiver {
 
         Intent intent = new Intent(sTargetChosenReceiveAction);
         intent.setPackage(reactContext.getPackageName());
+        intent.setClass(reactContext.getApplicationContext(), TargetChosenReceiver.class);
         intent.putExtra(EXTRA_RECEIVER_TOKEN, sLastRegisteredReceiver.hashCode());
         final PendingIntent callback = PendingIntent.getBroadcast(reactContext, 0, intent,
                 PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_ONE_SHOT);


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
Google Play rejects apps using this library because of an Implicit PendingIntent Vulnerability: https://support.google.com/faqs/answer/10437428

This PR should fix #1043

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
Verified that the sharing functionality works in my Android app with this fix
