### PR TITLE
Fix iOS Email URL sharing bug

### DIFF
--- a/ios/EmailShare.m
+++ b/ios/EmailShare.m
@@ -105,6 +105,7 @@
                 } else {
                     // if not a file, just append it to message
                     message = [message stringByAppendingString: [@" " stringByAppendingString: [RCTConvert NSString:options[@"url"]]] ];
+                    [mc setMessageBody:message isHTML:NO];
                 }
             }
                    


### PR DESCRIPTION
# Overview
Adding URL parameter in `shareSingle` method for `social` type `EMAIL`
https://github.com/react-native-share/react-native-share/issues/932

# Test Plan
Tested on iPhone before and after change

https://www.loom.com/share/d41d13e935774e4190fd44ab731d544d