### PR TITLE
Implement new step in documentation for Android SDK  30+

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-minimal

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-minimal

--- a/website/docs/installing.mdx
+++ b/website/docs/installing.mdx
@@ -161,6 +161,27 @@ Follow this to implement your `FileProvider`. If you have any doubt please you f
     }
     ```
 
+### Adding Queries for the Android (Necessary for SDK >= 30)
+
+Android 11 introduces changes related to package visibility.
+These changes affect apps only if they target Android 11.
+For more information on these changes, view the guides about [package visibility on Android](https://developer.android.com/training/package-visibility).
+This change can prevent you to use `Share.shareSingle()` or others!
+
+- In `AndroidManifest.xml` insert the `<queries>`.
+
+```
+<manifest package="com.example.game">
+    <queries>
+        <package android:name="com.example.store" />
+        <package android:name="com.example.services" />
+    </queries>
+    ...
+</manifest>
+```
+**Note:** Don't forget change the `android:name` in package for the package id of the app that you will share!
+
+
 ## Older versions
 
 If you need to use a older version of `react-native < 0.60`, then you will need to run a:


### PR DESCRIPTION
# Overview
I could not use `Share.shareSingle()` in Android 11 (Ever open the Google Play) then searching I see that Android 11 implements changes related to package visibility of others app.
My PR is implement documentation for others developers don't spend time searching a solution!
My closed issue about this is #1052 
If need read more about the changes [click here](https://developer.android.com/training/package-visibility)


