### PR TITLE
Specify PendingIntent.FLAG_IMMUTABLE for Android S+

### DIFF
--- a/android/src/main/java/cl/json/social/TargetChosenReceiver.java
+++ b/android/src/main/java/cl/json/social/TargetChosenReceiver.java
@@ -54,6 +54,8 @@ public class TargetChosenReceiver extends BroadcastReceiver {
         intent.setClass(reactContext.getApplicationContext(), TargetChosenReceiver.class);
         intent.putExtra(EXTRA_RECEIVER_TOKEN, sLastRegisteredReceiver.hashCode());
         final PendingIntent callback = PendingIntent.getBroadcast(reactContext, 0, intent,
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ?
+                PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_ONE_SHOT | PendingIntent.FLAG_IMMUTABLE :
                 PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_ONE_SHOT);
 
         return callback.getIntentSender();


### PR DESCRIPTION
# Overview

https://github.com/react-native-share/react-native-share/issues/1073 describes the issue.

Ref: Android 12 behavior changes https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability

# Test Plan
Apply the fix, and the project which targets Android 30 can successfully call `Share.open` without throwing.
