### PR TITLE
Resolve Promise on successful share for Android

### DIFF
--- a/android/src/main/java/cl/json/RNShareModule.java
+++ b/android/src/main/java/cl/json/RNShareModule.java
@@ -43,8 +43,12 @@ public class RNShareModule extends ReactContextBaseJavaModule implements Activit
 
     // removed @Override temporarily just to get it working on different versions of RN
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (requestCode == SHARE_REQUEST_CODE && resultCode == Activity.RESULT_CANCELED) {
-            TargetChosenReceiver.sendCallback(true, false, "CANCELED");
+        if (requestCode == SHARE_REQUEST_CODE) {
+            if (resultCode == Activity.RESULT_CANCELED) {
+                TargetChosenReceiver.sendCallback(true, false, "CANCELED");
+            } else if (resultCode == Activity.RESULT_OK) {
+                TargetChosenReceiver.sendCallback(true, true);
+            }
         }
     }
 


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Before this change, the Promise returned by calling `Share.open()` on Android would not resolve after a successful share, only if sharing was cancelled. Therefore, clients of the library could not handle completion of sharing, such as by removing a loading indicator. With this change, `Share.open()` on Android properly calls the success callback and resolves the Promise.

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Tested with our app's usage of react-native-share. Before this change, on Android, the Promise returned from `Share.open()` would not resolve after sharing the content, and so we wouldn't run the following line of code updating our `loading` state to `false`. With this change, `await Share.open(...)` would complete, the following line of code updating the `loading` state would run, and the loading indicator would be removed.

Let me know if you'd like me to test this in some other way as well.
