### PR TITLE
Set `LinkPresentation` as weak framwork on IOS

### DIFF
--- a/RNShare.podspec
+++ b/RNShare.podspec
@@ -15,4 +15,6 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency "React-Core"
+
+  s.ios.weak_framework = 'LinkPresentation'
 end


### PR DESCRIPTION
# Overview
Since `LinkPresentation` API is only available on iOS 13 and above, we need to mark the `LinkPresentaion` as a weak framework. Else, there will be a startup crash on iOS 12 instead of a build error `dyld: Library not loaded: /System/Library/Frameworks/LinkPresentation.framework/LinkPresentation`. 

Fixes #1095 


# Test Plan
Build the app on iOS 12 device, before the fix the app will crash on startup. And the app should work normally after the fix.
