### PR TITLE
Remove twitter native support on iOS

### DIFF
--- a/ios/GenericShare.m
+++ b/ios/GenericShare.m
@@ -17,8 +17,7 @@
     inAppBaseUrl:(NSString *)inAppBaseUrl {
 
     NSLog(@"Try open view");
-    if([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:inAppBaseUrl]]) {
-
+    if(![serviceType isEqualToString:@"com.apple.social.twitter"] && [[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:inAppBaseUrl]]) {
         SLComposeViewController *composeController = [SLComposeViewController  composeViewControllerForServiceType:serviceType];
 
         NSURL *URL = [RCTConvert NSURL:options[@"url"]];

--- a/website/docs/troubleshooting-ios.mdx
+++ b/website/docs/troubleshooting-ios.mdx
@@ -8,3 +8,8 @@ title: Troubleshooting iOS
 1. Check iOS SDK version running this command: `xcodebuild -showsdks`
 2. If your SDK is 12 or lower you need to update to Xcode 11 with iOS SDK 13
 3. Build the app with Xcode 11 and everything works ok
+
+### Twitter integration
+Since Twitter stop supporting SDK [(Check here)](https://blog.twitter.com/developer/en_us/topics/tools/2018/discontinuing-support-for-twitter-kit-sdk),
+it was rendering badly the post view. [(Like this)](https://github.com/react-native-share/react-native-share/issues/930)
+So, this library will open the browser, ant then the Twitter app will be launched


### PR DESCRIPTION
# Overview
As Twitter removed the support for the development kit, there is an issue in the visualization of a post. Related to https://github.com/react-native-share/react-native-share/issues/930


# Test Plan
Share a tweet using the library, this will open the browser, and if the phone has the app, then the Twitter app will be launched correctly.
