### PR TITLE
feat(android): add  `useInternalStorage` share option to avoid external storage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  react-native: react-native-community/react-native@5.3.0
+  react-native: react-native-community/react-native@6.0.0
 
 commands:
   checkout-attach-workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  react-native: react-native-community/react-native@6.0.0
+  react-native: react-native-community/react-native@6.0.1
 
 commands:
   checkout-attach-workspace:

--- a/android/src/main/java/cl/json/RNSharePathUtil.java
+++ b/android/src/main/java/cl/json/RNSharePathUtil.java
@@ -76,7 +76,7 @@ public class RNSharePathUtil {
                 final String type = split[0];
 
                 if ("primary".equalsIgnoreCase(type) || "0".equalsIgnoreCase(type)) {
-                    return filePrefix + context.getExternalCacheDir() + "/" + split[1];
+                    return filePrefix + context.getCacheDir() + "/" + split[1];
                 } else if ("raw".equalsIgnoreCase(type)) {
                     return filePrefix + split[1];
                 } else if (!TextUtils.isEmpty(type)) {

--- a/android/src/main/java/cl/json/RNSharePathUtil.java
+++ b/android/src/main/java/cl/json/RNSharePathUtil.java
@@ -76,7 +76,7 @@ public class RNSharePathUtil {
                 final String type = split[0];
 
                 if ("primary".equalsIgnoreCase(type) || "0".equalsIgnoreCase(type)) {
-                    String cacheDir = useInternalStorage ? context.getCacheDir() : context.getExternalCacheDir()
+                    File cacheDir = useInternalStorage ? context.getCacheDir() : context.getExternalCacheDir();
                     return filePrefix + cacheDir + "/" + split[1];
                 } else if ("raw".equalsIgnoreCase(type)) {
                     return filePrefix + split[1];

--- a/android/src/main/java/cl/json/RNSharePathUtil.java
+++ b/android/src/main/java/cl/json/RNSharePathUtil.java
@@ -63,7 +63,7 @@ public class RNSharePathUtil {
         return result;
     }
 
-    public static String getRealPathFromURI(final Context context, final Uri uri) {
+    public static String getRealPathFromURI(final Context context, final Uri uri, Boolean useInternalStorage) {
 
         String filePrefix = "";
         // DocumentProvider
@@ -76,7 +76,8 @@ public class RNSharePathUtil {
                 final String type = split[0];
 
                 if ("primary".equalsIgnoreCase(type) || "0".equalsIgnoreCase(type)) {
-                    return filePrefix + context.getCacheDir() + "/" + split[1];
+                    String cacheDir = useInternalStorage ? context.getCacheDir() : context.getExternalCacheDir()
+                    return filePrefix + cacheDir + "/" + split[1];
                 } else if ("raw".equalsIgnoreCase(type)) {
                     return filePrefix + split[1];
                 } else if (!TextUtils.isEmpty(type)) {

--- a/android/src/main/java/cl/json/ShareFile.java
+++ b/android/src/main/java/cl/json/ShareFile.java
@@ -111,7 +111,7 @@ public class ShareFile {
         return this.type;
     }
     private String getRealPathFromURI(Uri contentUri) {
-        String result = RNSharePathUtil.getRealPathFromURI(this.reactContext, contentUri);
+        String result = RNSharePathUtil.getRealPathFromURI(this.reactContext,  contentUri, this.useInternalStorage);
         return result;
     }
     public Uri getURI() {

--- a/android/src/main/java/cl/json/ShareFile.java
+++ b/android/src/main/java/cl/json/ShareFile.java
@@ -123,8 +123,8 @@ public class ShareFile {
             String encodedImg = this.uri.toString().substring(BASE_64_DATA_LENGTH + this.type.length() + BASE_64_DATA_OFFSET);
             String filename = this.filename != null ? this.filename : System.nanoTime() + "";
             try {
-                String cacheDir = this.useInternalStorage ? this.reactContext.getCacheDir() : this.reactContext.getExternalCacheDir()
-                File dir = new File(cacheDir, Environment.DIRECTORY_DOWNLOADS );
+                File cacheDir = this.useInternalStorage ? this.reactContext.getCacheDir() : this.reactContext.getExternalCacheDir();
+                File dir = new File(cacheDir, Environment.DIRECTORY_DOWNLOADS);
                 if (!dir.exists() && !dir.mkdirs()) {
                     throw new IOException("mkdirs failed on " + dir.getAbsolutePath());
                 }

--- a/android/src/main/java/cl/json/ShareFile.java
+++ b/android/src/main/java/cl/json/ShareFile.java
@@ -23,18 +23,19 @@ public class ShareFile {
     private Uri uri;
     private String type;
     private String filename;
+    private Boolean useInternalStorage;
 
-    public ShareFile(String url, String type, String filename, ReactApplicationContext reactContext){
-        this(url, filename, reactContext);
+    public ShareFile(String url, String type, String filename, Boolean useInternalStorage, ReactApplicationContext reactContext){
+        this(url, filename, useInternalStorage, reactContext);
         this.type = type;
-        this.filename = filename;
     }
 
-    public ShareFile(String url, String filename, ReactApplicationContext reactContext){
+    public ShareFile(String url, String filename, Boolean useInternalStorage, ReactApplicationContext reactContext){
         this.url = url;
         this.uri = Uri.parse(this.url);
-        this.reactContext = reactContext;
         this.filename = filename;
+        this.useInternalStorage = useInternalStorage;
+        this.reactContext = reactContext;
     }
     /**
      * Obtain mime type from URL
@@ -122,7 +123,8 @@ public class ShareFile {
             String encodedImg = this.uri.toString().substring(BASE_64_DATA_LENGTH + this.type.length() + BASE_64_DATA_OFFSET);
             String filename = this.filename != null ? this.filename : System.nanoTime() + "";
             try {
-                File dir = new File(this.reactContext.getCacheDir(), Environment.DIRECTORY_DOWNLOADS );
+                String cacheDir = this.useInternalStorage ? this.reactContext.getCacheDir() : this.reactContext.getExternalCacheDir()
+                File dir = new File(cacheDir, Environment.DIRECTORY_DOWNLOADS );
                 if (!dir.exists() && !dir.mkdirs()) {
                     throw new IOException("mkdirs failed on " + dir.getAbsolutePath());
                 }

--- a/android/src/main/java/cl/json/ShareFile.java
+++ b/android/src/main/java/cl/json/ShareFile.java
@@ -122,7 +122,7 @@ public class ShareFile {
             String encodedImg = this.uri.toString().substring(BASE_64_DATA_LENGTH + this.type.length() + BASE_64_DATA_OFFSET);
             String filename = this.filename != null ? this.filename : System.nanoTime() + "";
             try {
-                File dir = new File(this.reactContext.getExternalCacheDir(), Environment.DIRECTORY_DOWNLOADS );
+                File dir = new File(this.reactContext.getCacheDir(), Environment.DIRECTORY_DOWNLOADS );
                 if (!dir.exists() && !dir.mkdirs()) {
                     throw new IOException("mkdirs failed on " + dir.getAbsolutePath());
                 }

--- a/android/src/main/java/cl/json/ShareFiles.java
+++ b/android/src/main/java/cl/json/ShareFiles.java
@@ -126,7 +126,7 @@ public class ShareFiles
     }
 
     private String getRealPathFromURI(Uri contentUri) {
-        String result = RNSharePathUtil.getRealPathFromURI(this.reactContext, contentUri);
+        String result = RNSharePathUtil.getRealPathFromURI(this.reactContext, contentUri, this.useInternalStorage);
         return result;
     }
 

--- a/android/src/main/java/cl/json/ShareFiles.java
+++ b/android/src/main/java/cl/json/ShareFiles.java
@@ -141,7 +141,7 @@ public class ShareFiles
                 String encodedImg = uri.getSchemeSpecificPart().substring(uri.getSchemeSpecificPart().indexOf(";base64,") + 8);
                 String fileName = filenames.size() >= uriIndex + 1 ? filenames.get(uriIndex) : (System.currentTimeMillis() + "." + extension);
                 try {
-                    File dir = new File(this.reactContext.getExternalCacheDir(), Environment.DIRECTORY_DOWNLOADS );
+                    File dir = new File(this.reactContext.getCacheDir(), Environment.DIRECTORY_DOWNLOADS );
                     if (!dir.exists() && !dir.mkdirs()) {
                         throw new IOException("mkdirs failed on " + dir.getAbsolutePath());
                     }

--- a/android/src/main/java/cl/json/ShareFiles.java
+++ b/android/src/main/java/cl/json/ShareFiles.java
@@ -23,13 +23,14 @@ public class ShareFiles
     private ArrayList<Uri> uris;
     private ArrayList<String> filenames;
     private String intentType;
+    private Boolean useInternalStorage;
 
-    public ShareFiles(ReadableArray urls, ArrayList<String> filenames, String type, ReactApplicationContext reactContext) {
+    public ShareFiles(ReadableArray urls, ArrayList<String> filenames, String type, Boolean useInternalStorage, ReactApplicationContext reactContext) {
         this(urls, filenames, reactContext);
         this.intentType = type;
     }
 
-    public ShareFiles(ReadableArray urls, ArrayList<String> filenames, ReactApplicationContext reactContext) {
+    public ShareFiles(ReadableArray urls, ArrayList<String> filenames, Boolean useInternalStorage, ReactApplicationContext reactContext) {
         this.uris = new ArrayList<>();
         for (int i = 0; i < urls.size(); i++) {
             String url = urls.getString(i);
@@ -39,6 +40,7 @@ public class ShareFiles
             }
         }
         this.filenames = filenames;
+        this.useInternalStorage = useInternalStorage;
         this.reactContext = reactContext;
     }
     /**
@@ -141,7 +143,8 @@ public class ShareFiles
                 String encodedImg = uri.getSchemeSpecificPart().substring(uri.getSchemeSpecificPart().indexOf(";base64,") + 8);
                 String fileName = filenames.size() >= uriIndex + 1 ? filenames.get(uriIndex) : (System.currentTimeMillis() + "." + extension);
                 try {
-                    File dir = new File(this.reactContext.getCacheDir(), Environment.DIRECTORY_DOWNLOADS );
+                    String cacheDir = this.useInternalStorage ? this.reactContext.getCacheDir() : this.reactContext.getExternalCacheDir()
+                    File dir = new File(cacheDir, Environment.DIRECTORY_DOWNLOADS );
                     if (!dir.exists() && !dir.mkdirs()) {
                         throw new IOException("mkdirs failed on " + dir.getAbsolutePath());
                     }

--- a/android/src/main/java/cl/json/ShareFiles.java
+++ b/android/src/main/java/cl/json/ShareFiles.java
@@ -26,7 +26,7 @@ public class ShareFiles
     private Boolean useInternalStorage;
 
     public ShareFiles(ReadableArray urls, ArrayList<String> filenames, String type, Boolean useInternalStorage, ReactApplicationContext reactContext) {
-        this(urls, filenames, reactContext);
+        this(urls, filenames, useInternalStorage, reactContext);
         this.intentType = type;
     }
 
@@ -143,8 +143,8 @@ public class ShareFiles
                 String encodedImg = uri.getSchemeSpecificPart().substring(uri.getSchemeSpecificPart().indexOf(";base64,") + 8);
                 String fileName = filenames.size() >= uriIndex + 1 ? filenames.get(uriIndex) : (System.currentTimeMillis() + "." + extension);
                 try {
-                    String cacheDir = this.useInternalStorage ? this.reactContext.getCacheDir() : this.reactContext.getExternalCacheDir()
-                    File dir = new File(cacheDir, Environment.DIRECTORY_DOWNLOADS );
+                    File cacheDir = this.useInternalStorage ? this.reactContext.getCacheDir() : this.reactContext.getExternalCacheDir();
+                    File dir = new File(cacheDir, Environment.DIRECTORY_DOWNLOADS);
                     if (!dir.exists() && !dir.mkdirs()) {
                         throw new IOException("mkdirs failed on " + dir.getAbsolutePath());
                     }

--- a/android/src/main/java/cl/json/social/FacebookStoriesShare.java
+++ b/android/src/main/java/cl/json/social/FacebookStoriesShare.java
@@ -81,6 +81,11 @@ public class FacebookStoriesShare extends SingleShareIntent {
             this.intent.putExtra("bottom_background_color", options.getString("backgroundBottomColor"));
         }
 
+        Boolean useInternalStorage = false;
+        if (this.hasValidKey("useInternalStorage", options)) {
+            useInternalStorage = options.getBoolean("useInternalStorage");
+        }
+
         Boolean hasBackgroundAsset = this.hasValidKey("backgroundImage", options)
                 || this.hasValidKey("backgroundVideo", options);
 
@@ -93,14 +98,14 @@ public class FacebookStoriesShare extends SingleShareIntent {
                 backgroundFileName = options.getString("backgroundVideo");
             }
 
-            ShareFile backgroundAsset = new ShareFile(backgroundFileName, "background", this.reactContext);
+            ShareFile backgroundAsset = new ShareFile(backgroundFileName, "background", useInternalStorage, this.reactContext);
 
             this.intent.setDataAndType(backgroundAsset.getURI(), backgroundAsset.getType());
             this.intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         }
 
         if (this.hasValidKey("stickerImage", options)) {
-            ShareFile stickerAsset = new ShareFile(options.getString("stickerImage"), "sticker", this.reactContext);
+            ShareFile stickerAsset = new ShareFile(options.getString("stickerImage"), "sticker", useInternalStorage, this.reactContext);
 
             if (!hasBackgroundAsset) {
                 this.intent.setType("image/*");

--- a/android/src/main/java/cl/json/social/InstagramStoriesShare.java
+++ b/android/src/main/java/cl/json/social/InstagramStoriesShare.java
@@ -76,6 +76,11 @@ public class InstagramStoriesShare extends SingleShareIntent {
             this.intent.putExtra("bottom_background_color", options.getString("backgroundBottomColor"));
         }
 
+        Boolean useInternalStorage = false;
+        if (this.hasValidKey("useInternalStorage", options)) {
+            useInternalStorage = options.getBoolean("useInternalStorage");
+        }
+
         Boolean hasBackgroundAsset = this.hasValidKey("backgroundImage", options)
                 || this.hasValidKey("backgroundVideo", options);
 
@@ -88,14 +93,14 @@ public class InstagramStoriesShare extends SingleShareIntent {
                 backgroundFileName = options.getString("backgroundVideo");
             }
 
-            ShareFile backgroundAsset = new ShareFile(backgroundFileName, "background", this.reactContext);
+            ShareFile backgroundAsset = new ShareFile(backgroundFileName, "background", useInternalStorage, this.reactContext);
 
             this.intent.setDataAndType(backgroundAsset.getURI(), backgroundAsset.getType());
             this.intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         }
 
         if (this.hasValidKey("stickerImage", options)) {
-            ShareFile stickerAsset = new ShareFile(options.getString("stickerImage"), "sticker", this.reactContext);
+            ShareFile stickerAsset = new ShareFile(options.getString("stickerImage"), "sticker", useInternalStorage, this.reactContext);
 
             if (!hasBackgroundAsset) {
                 this.intent.setType("image/*");

--- a/android/src/main/java/cl/json/social/ShareIntent.java
+++ b/android/src/main/java/cl/json/social/ShareIntent.java
@@ -135,7 +135,7 @@ public abstract class ShareIntent {
                 this.getIntent().putExtra("jid", chatAddress);
             }
         }
-        
+
         if (socialType.equals("whatsappbusiness")) {
             if (options.hasKey("whatsAppNumber")) {
                 String whatsAppNumber = options.getString("whatsAppNumber");
@@ -186,14 +186,19 @@ public abstract class ShareIntent {
     }
 
     protected ShareFile getFileShare(ReadableMap options) {
-         String filename = null;
+        String filename = null;
         if (ShareIntent.hasValidKey("filename", options)) {
             filename = options.getString("filename");
         }
+
+        Boolean useInternalStorage = false;
+        if (ShareIntent.hasValidKey("useInternalStorage", options)) {
+            useInternalStorage = options.getBoolean("useInternalStorage");
+        }
         if (ShareIntent.hasValidKey("type", options)) {
-            return new ShareFile(options.getString("url"), options.getString("type"), filename, this.reactContext);
+            return new ShareFile(options.getString("url"), options.getString("type"), filename, useInternalStorage, this.reactContext);
         } else {
-            return new ShareFile(options.getString("url"), filename, this.reactContext);
+            return new ShareFile(options.getString("url"), filename, useInternalStorage, this.reactContext);
         }
     }
 
@@ -206,10 +211,14 @@ public abstract class ShareIntent {
             }
         }
 
+        Boolean useInternalStorage = false;
+        if (ShareIntent.hasValidKey("useInternalStorage", options)) {
+            useInternalStorage = options.getBoolean("useInternalStorage");
+        }
         if (ShareIntent.hasValidKey("type", options)) {
-            return new ShareFiles(options.getArray("urls"), filenames, options.getString("type"), this.reactContext);
+            return new ShareFiles(options.getArray("urls"), filenames, options.getString("type"), useInternalStorage, this.reactContext);
         } else {
-            return new ShareFiles(options.getArray("urls"), filenames, this.reactContext);
+            return new ShareFiles(options.getArray("urls"), filenames, useInternalStorage, this.reactContext);
         }
     }
 

--- a/website/docs/share-open.mdx
+++ b/website/docs/share-open.mdx
@@ -50,6 +50,7 @@ You can customize the call to `Share.open` passing the following parameters:
 | saveToFiles           |    boolean    | Open only `Files` app (supports only urls (base64 string or path), requires iOS 11 or later)                                                                   | ✅       | 🚫      | ✅  | ❓      |
 | filenames             | Array[string] | Array of filename for base64 urls array in Android                                                                                                             | ✅       | ✅      | 🚫  | ❓      |
 | activityItemSources   | Array[Object] | Array of activity item sources. Each items should conform to [ActivityItemSource](#activityitemsource) specification. [Example](#example-activityitemsources). | ✅       | 🚫      | ✅  | ❓      |
+| useInternalStorage    |    boolean    | Store the temporary file in the internal storage cache (Android only)                                                                                          | ✅       | ✅      | 🚫  | 🚫      |
 
 ## Sharing a base64 file format
 

--- a/website/docs/share-single.mdx
+++ b/website/docs/share-single.mdx
@@ -45,42 +45,43 @@ Or with `async/await`:
 
 You can pass the option that will be handled by the native code, similar to `Share.open`.
 
-| Name  | Type     | Description | Optional | Android | iOS | Windows
-| :---- | :------: | :--- | :--- | :--- | :--- | :--- |
-| url | string   | URL you want to share | ✅ |  ✅ | ✅ | ❓
-| type | string   | File mime type | ✅ |  ✅ | ✅ | ❓
-| filename | string   | Custom file name for email attachment | ✅ |  ✅ | ✅ | ❓
-| message | string   | Message sent to the share activity | ✅ |  ✅ | ✅ | ❓
-| title | string   |  Title sent to the share activity | ✅ |  ✅ | ✅ | ❓
-| subject | string   | Subject sent when sharing to email | ✅ | ✅ | ✅  | ❓
-| email | string   | Email of addressee | ✅ | ✅ | ✅  | ❓
-| recipient | string | Phone number of SMS recipient | ✅ | ✅ | 🚫 | 🚫
-| social | string   | supported social apps: [List](#static-values-for-social)  | 🚫 | ✅ | ✅  | ❓
-| forceDialog | boolean | (optional) only android. Avoid showing dialog with buttons Just Once / Always. Useful for Instagram to always ask user if share as Story or Feed | ✅ | ✅ | ✅  | ❓
+| Name               |  Type   | Description                                                                                                                                      | Optional | Android | iOS | Windows |
+| :----------------- | :-----: | :----------------------------------------------------------------------------------------------------------------------------------------------- | :------- | :------ | :-- | :------ |
+| url                | string  | URL you want to share                                                                                                                            | ✅       | ✅      | ✅  | ❓      |
+| type               | string  | File mime type                                                                                                                                   | ✅       | ✅      | ✅  | ❓      |
+| filename           | string  | Custom file name for email attachment                                                                                                            | ✅       | ✅      | ✅  | ❓      |
+| message            | string  | Message sent to the share activity                                                                                                               | ✅       | ✅      | ✅  | ❓      |
+| title              | string  | Title sent to the share activity                                                                                                                 | ✅       | ✅      | ✅  | ❓      |
+| subject            | string  | Subject sent when sharing to email                                                                                                               | ✅       | ✅      | ✅  | ❓      |
+| email              | string  | Email of addressee                                                                                                                               | ✅       | ✅      | ✅  | ❓      |
+| recipient          | string  | Phone number of SMS recipient                                                                                                                    | ✅       | ✅      | 🚫  | 🚫      |
+| social             | string  | supported social apps: [List](#static-values-for-social)                                                                                         | 🚫       | ✅      | ✅  | ❓      |
+| forceDialog        | boolean | (optional) only android. Avoid showing dialog with buttons Just Once / Always. Useful for Instagram to always ask user if share as Story or Feed | ✅       | ✅      | ✅  | ❓      |
+| useInternalStorage | boolean | Store the temporary file in the internal storage cache (Android only)                                                                            | ✅       | ✅      | 🚫  | 🚫      |
 
-***NOTE: If both `message` and `url` are provided, `url` will be concatenated to the end of `message` to form the body of the message. If only one is provided it will be used***
+**_NOTE: If both `message` and `url` are provided, `url` will be concatenated to the end of `message` to form the body of the message. If only one is provided it will be used_**
 
 ## Supported Applications
 
 `react-native-share` export a `enum` containing all supported apps, wich can be seen [here](https://github.com/react-native-community/react-native-share/blob/5299d95aab25bfba6815e0f5455876897ed8ddc6/index.js#L207-L219).
 
-| Name  | Android     | iOS | Windows |
-| :---- | :------: | :--- | :---
-| **FACEBOOK** | ✅   | ✅ | 🚫 |
-| **FACEBOOK_STORIES** | ✅   | ✅ | 🚫 |
-| **PAGESMANAGER** | ✅   | 🚫 | 🚫 |
-| **WHATSAPP** | ✅   | ✅ | 🚫 |
-| **WHATSAPPBUSINESS** | ✅   | 🚫 | 🚫 |
-| **INSTAGRAM** | ✅   | ✅ | 🚫 |
-| **INSTAGRAM_STORIES** | ✅   | ✅ | 🚫 |
-| **GOOGLEPLUS** | ✅   | ✅ | 🚫 |
-| **EMAIL** | ✅   | ✅ | 🚫 |
-| **PINTEREST** | ✅   | 🚫 | 🚫 |
-| **SMS** | ✅   | 🚫 | 🚫 |
-| **SNAPCHAT** | ✅   | 🚫 | 🚫 |
-| **MESSENGER** | ✅   | 🚫 | 🚫 |
-| **LINKEDIN** | ✅   | 🚫 | 🚫 |
-| **TELEGRAM** | ✅   | ✅ | 🚫 |
+| Name                  | Android | iOS | Windows |
+| :-------------------- | :-----: | :-- | :------ |
+| **FACEBOOK**          |   ✅    | ✅  | 🚫      |
+| **FACEBOOK_STORIES**  |   ✅    | ✅  | 🚫      |
+| **PAGESMANAGER**      |   ✅    | 🚫  | 🚫      |
+| **WHATSAPP**          |   ✅    | ✅  | 🚫      |
+| **WHATSAPPBUSINESS**  |   ✅    | 🚫  | 🚫      |
+| **INSTAGRAM**         |   ✅    | ✅  | 🚫      |
+| **INSTAGRAM_STORIES** |   ✅    | ✅  | 🚫      |
+| **GOOGLEPLUS**        |   ✅    | ✅  | 🚫      |
+| **EMAIL**             |   ✅    | ✅  | 🚫      |
+| **PINTEREST**         |   ✅    | 🚫  | 🚫      |
+| **SMS**               |   ✅    | 🚫  | 🚫      |
+| **SNAPCHAT**          |   ✅    | 🚫  | 🚫      |
+| **MESSENGER**         |   ✅    | 🚫  | 🚫      |
+| **LINKEDIN**          |   ✅    | 🚫  | 🚫      |
+| **TELEGRAM**          |   ✅    | ✅  | 🚫      |
 
 ## Static values for Instagram Stories
 


### PR DESCRIPTION
# Overview
Hey hey !
We've noticed that this library is using `getExternalCacheDir`, which usually returns `/sdcard/Android/data/com.package.name/cache`. The thing is, on Android <= 10, this directory can be accessed by any application that has the `WRITE_EXTERNAL_STORAGE` permission, and this can basically lead to any malicious application accessing the previous files you shared. In our case, we share sensitive information, and we don't want them to leak.

I added a `useInternalStorage` option that is replacing it by `getCacheDir` which returns `/data/data/com.package.name/cache`, that can only be accessed by the application with the `com.package.name` identifier.


# Test Plan
I tested it locally and it works fine. My flow was:
- Share a file
- Check that `/sdcard/Android/data/com.package.name/cache` is still empty
- Check that the file is stored in `/data/data/com.package.name/cache`
- Check that the file is correctly shared
