### PR TITLE
fix(instagram): fix black screen issue for instagram stories with Social.Instagram

### DIFF
--- a/android/src/main/java/cl/json/social/InstagramShare.java
+++ b/android/src/main/java/cl/json/social/InstagramShare.java
@@ -58,7 +58,8 @@ public class InstagramShare extends SingleShareIntent {
     }
 
     protected void openInstagramIntentChooserForImage(String url, String chooserTitle) {
-        ShareFile shareFile = new ShareFile(url, "image/jpeg", "image" , this.reactContext);
+        Boolean shouldUseInternalStorage = ShareIntent.hasValidKey("useInternalStorage", options) && options.getBoolean("useInternalStorage");
+        ShareFile shareFile = new ShareFile(url, "image/jpeg", "image", shouldUseInternalStorage, this.reactContext);
         Uri uri = shareFile.getURI();
 
         Intent feedIntent = new Intent(Intent.ACTION_SEND);

--- a/android/src/main/java/cl/json/social/InstagramShare.java
+++ b/android/src/main/java/cl/json/social/InstagramShare.java
@@ -32,7 +32,13 @@ public class InstagramShare extends SingleShareIntent {
                 return;
             }
             String url = options.getString("url");
+
             Boolean isUrlScheme = url.startsWith("instagram://");
+            if (isUrlScheme) {
+                openInstagramUrlScheme(url);
+                return;
+            }
+
 
             if (!ShareIntent.hasValidKey("type", options)) {
                 Log.e("RNShare", "No type provided");
@@ -41,9 +47,7 @@ public class InstagramShare extends SingleShareIntent {
             String type = options.getString("type");
             Boolean isImage = type.startsWith("image");
 
-            if (isUrlScheme) {
-                openInstagramUrlScheme(url);
-            } else if(isImage) {
+            if (isImage) {
                 this.openInstagramIntentChooserForImage(url, chooserTitle);
             } else {
                 super.openIntentChooser();

--- a/android/src/main/java/cl/json/social/InstagramShare.java
+++ b/android/src/main/java/cl/json/social/InstagramShare.java
@@ -1,14 +1,15 @@
 package cl.json.social;
 
+import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
-import java.io.File;
-import android.os.Environment;
 import android.net.Uri;
 import android.util.Log;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableMap;
+
+import cl.json.ShareFile;
 
 /**
  * Created by Ralf Nieuwenhuizen on 10-04-17.
@@ -24,17 +25,59 @@ public class InstagramShare extends SingleShareIntent {
 
     @Override
     public void open(ReadableMap options) throws ActivityNotFoundException {
-        super.open(options);
-        try {
-            // passing instagram://share as url option opens Publishing screen with camera view
-            if (ShareIntent.hasValidKey("url", options) && options.getString("url").startsWith("instagram://")) {
-                this.getIntent().setAction(Intent.ACTION_VIEW);
-                this.getIntent().setData(Uri.parse(options.getString("url")));
+            super.open(options);
+
+            if (!ShareIntent.hasValidKey("url", options)) {
+                Log.e("RNShare", "No url provided");
+                return;
             }
-        } catch (Exception e) {
-            Log.w("RNShare", e.getMessage());
-        }
-        this.openIntentChooser();
+            String url = options.getString("url");
+            Boolean isUrlScheme = url.startsWith("instagram://");
+
+            if (!ShareIntent.hasValidKey("type", options)) {
+                Log.e("RNShare", "No type provided");
+                return;
+            }
+            String type = options.getString("type");
+            Boolean isImage = type.startsWith("image");
+
+            if (isUrlScheme) {
+                openInstagramUrlScheme(url);
+            } else if(isImage) {
+                this.openInstagramIntentChooserForImage(url, chooserTitle);
+            } else {
+                super.openIntentChooser();
+            }
+    }
+
+    protected void openInstagramUrlScheme(String url) {
+            Uri uri = Uri.parse(url);
+            this.getIntent().setAction(Intent.ACTION_VIEW);
+            this.getIntent().setData(uri);
+            super.openIntentChooser();
+    }
+
+    protected void openInstagramIntentChooserForImage(String url, String chooserTitle) {
+        ShareFile shareFile = new ShareFile(url, "image/jpeg", "image" , this.reactContext);
+        Uri uri = shareFile.getURI();
+
+        Intent feedIntent = new Intent(Intent.ACTION_SEND);
+        feedIntent.setType("image/*");
+        feedIntent.putExtra(Intent.EXTRA_STREAM, uri);
+        feedIntent.setPackage(PACKAGE);
+
+        Intent storiesIntent = new Intent("com.instagram.share.ADD_TO_STORY");
+        storiesIntent.setDataAndType(uri, "jpg");
+        storiesIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        storiesIntent.setPackage(PACKAGE);
+
+        Intent chooserIntent = Intent.createChooser(feedIntent, chooserTitle);
+        chooserIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, new Intent[] {storiesIntent});
+
+        Activity activity = this.reactContext.getCurrentActivity();
+        activity.grantUriPermission(PACKAGE, uri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        this.reactContext.startActivity(chooserIntent);
     }
 
     @Override

--- a/website/docs/share-single.mdx
+++ b/website/docs/share-single.mdx
@@ -48,7 +48,7 @@ You can pass the option that will be handled by the native code, similar to `Sha
 | Name               |  Type   | Description                                                                                                                                      | Optional | Android | iOS | Windows |
 | :----------------- | :-----: | :----------------------------------------------------------------------------------------------------------------------------------------------- | :------- | :------ | :-- | :------ |
 | url                | string  | URL you want to share                                                                                                                            | ✅       | ✅      | ✅  | ❓      |
-| type               | string  | File mime type                                                                                                                                   | ✅       | ✅      | ✅  | ❓      |
+| type               | string  | File mime type (required for sharing file with `INSTAGRAM`)                                                                                                                                  | ✅       | ✅      | ✅  | ❓      |
 | filename           | string  | Custom file name for email attachment                                                                                                            | ✅       | ✅      | ✅  | ❓      |
 | message            | string  | Message sent to the share activity                                                                                                               | ✅       | ✅      | ✅  | ❓      |
 | title              | string  | Title sent to the share activity                                                                                                                 | ✅       | ✅      | ✅  | ❓      |
@@ -83,7 +83,9 @@ You can pass the option that will be handled by the native code, similar to `Sha
 | **LINKEDIN**          |   ✅    | 🚫  | 🚫      |
 | **TELEGRAM**          |   ✅    | ✅  | 🚫      |
 
-## Static values for Instagram Stories
+## Instagram
+
+### Share Instagram Stories
 
 These values can be used when you are calling the method `Share.single` passing the attributes that you need (You can combine these attributes, Story will use properties that you pass).
 
@@ -101,12 +103,56 @@ const shareOptions = {
 
 Share.shareSingle(shareOptions);
 ```
+#### Supported options for INSTAGRAM_STORIES:
 
-## Opening Instagram Share Screen (Camera view)
+| Name  | Type     | Description | Optional |
+| :---- | :------: | :--- | :--- |
+| backgroundImage | string   | URL you want to share | ✅
+| stickerImage | string   | URL you want to share | ✅
+| backgroundBottomColor | string   | default #837DF4 | ✅
+| backgroundTopColor | string   | default #906df4 | ✅
+| attributionURL | string   | (optional) facebook beta-test | ✅
+| backgroundVideo | string   | URL you want to share | ✅
+
+### Share image to Instagram
+
+```js
+import Share, { Social } from 'react-native-share'
+
+await Share.shareSingle({
+      social: Share.Social.INSTAGRAM,
+      url: 'data:image/png;base64,<imageInBase64>',
+      type: 'image/*'
+    });
+```
+
+
+### Share remote videos to Instagram
+Instagram tries to select **the very last file of the cameraroll** so you have to save videos to the cameraroll in case you want to share them to Instagram.
+```js
+import Share from 'react-native-share';
+import RNFetchBlob from 'rn-fetch-blob';
+import CameraRoll from '@react-native-community/cameraroll';
+
+const cache = await RNFetchBlob.config({
+            fileCache: true,
+            appendExt: 'mp4',
+          }).fetch('GET', "YOUR OWN REMOTE VIDEO URL", {});
+const gallery = await CameraRoll.save(cache.path(), 'video');
+cache.flush();
+await Share.shareSingle({
+    social: Share.Social.INSTAGRAM,
+    url: gallery,
+    type: "video/*"
+});
+```
+
+
+### Opening Instagram Share Screen (Camera view)
 
 By default IG opens New post view with Camera View. There you can find also story and gallery view to pick multiple pictures to publish.
 
-### Android + IOS
+#### Android + IOS
 ```js
 import Share from 'react-native-share';
 
@@ -118,7 +164,7 @@ const shareOptions = {
 Share.shareSingle(shareOptions);
 ```
 
-### Android
+#### Android
 ```js
 import Share from 'react-native-share';
 
@@ -134,20 +180,9 @@ URL patterns like `instagram://` can be used on Android, but works different the
 https://developers.facebook.com/docs/instagram/sharing-to-feed/
 
 
-### Supported options for INSTAGRAM_STORIES:
+## Facebook
 
-Use this properties to customize the instagram storie view.
-
-| Name  | Type     | Description | Optional |
-| :---- | :------: | :--- | :--- |
-| backgroundImage | string   | URL you want to share | ✅
-| stickerImage | string   | URL you want to share | ✅
-| backgroundBottomColor | string   | default #837DF4 | ✅
-| backgroundTopColor | string   | default #906df4 | ✅
-| attributionURL | string   | (optional) facebook beta-test | ✅
-| backgroundVideo | string   | URL you want to share | ✅
-
-## Static Values for Facebook Stories
+### Static Values for Facebook Stories
 
 These values can be used when you are calling the method `Share.single` passing the attributes that you need (You can combine these attributes, Story will use properties that you pass).
 
@@ -168,7 +203,7 @@ const shareOptions = {
 Share.shareSingle(shareOptions);
 ```
 
-Supported options for `FACEBOOK_STORIES`:
+#### Supported options for `FACEBOOK_STORIES`:
 
 | Name  | Type     | Description |
 | :---- | :------: | :--- |
@@ -182,24 +217,8 @@ Supported options for `FACEBOOK_STORIES`:
 
 \* check the platform specific documentation ([Android](https://developers.facebook.com/docs/sharing/sharing-to-stories/android-developers)/[iOS](https://developers.facebook.com/docs/sharing/sharing-to-stories/ios-developers)) to understand the differences between them.
 
-### Share remote videos to Instagram
-Instagram tries to select **the very last file of the cameraroll** so you have to save videos to the cameraroll in case you want to share them to Instagram.
-```js
-import Share from 'react-native-share';
-import RNFetchBlob from 'rn-fetch-blob';
-import CameraRoll from '@react-native-community/cameraroll';
+## Telegram
 
-const cache = await RNFetchBlob.config({
-            fileCache: true,
-            appendExt: 'mp4',
-          }).fetch('GET', "YOUR OWN REMOTE VIDEO URL", {});
-const gallery = await CameraRoll.save(cache.path(), 'video');
-cache.flush();
-await Share.shareSingle({
-    social: Share.Social.INSTAGRAM,
-    url: gallery,
-});
-```
 ### Share Intent to Telegram
 ```js
 Share.shareSingle({


### PR DESCRIPTION
# Overview
Sharing to Instagram using `shareSingle` and the `social` property `Social.Instagram` opens an intent chooser that lets the user decide between sharing as Instagram Direct, Feed, or Stories. Direct and Feed are working but Stories doesn't.
The issue looks similar to [this one](https://github.com/react-native-share/react-native-share/issues/1084)

For sharing as Stories, instead of using the Android intent action `ACTION_SEND`, one needs to use the action ` "com.instagram.share.ADD_TO_STORY"` as in the Instagram documentation [example](https://developers.facebook.com/docs/instagram/sharing-to-stories).

To fix the issue - and only for image data - we create a chooser intent that combines the `ACTION_SEND` intent and the Instagram `ADD_TO_STORY`  intent as extra initial intent. The approach is based on [this gist](https://gist.github.com/michaeltys/a8613e5aea9db8e4684bf85568e40160).

# Test Plan
Use `shareSingle` function with the `Social.Instagram` `social` property.

1. with a scheme url, like ` 'instagram://share'` => should not have changed
2. with image data => the black screen issue has been fixed
3. with another data  => should not have changed