### PR TITLE
Fixed android instagram stories black screen

### DIFF
--- a/android/src/main/java/cl/json/social/InstagramStoriesShare.java
+++ b/android/src/main/java/cl/json/social/InstagramStoriesShare.java
@@ -93,7 +93,7 @@ public class InstagramStoriesShare extends SingleShareIntent {
                 backgroundFileName = options.getString("backgroundVideo");
             }
 
-            ShareFile backgroundAsset = new ShareFile(backgroundFileName, "background", useInternalStorage, this.reactContext);
+            ShareFile backgroundAsset = new ShareFile(backgroundFileName, "image/jpeg", "background", useInternalStorage, this.reactContext);
 
             this.intent.setDataAndType(backgroundAsset.getURI(), backgroundAsset.getType());
             this.intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);


### PR DESCRIPTION
Solution found by https://github.com/marf on this thread https://github.com/react-native-share/react-native-share/issues/1084#issuecomment-932348328

# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
Kia ora! Currently on the android side of the library, when sharing to an instagram story your image won't appear, and instead you'll see a blackscreen. @marf found a solution, and I've implemented it here. 

There was another PR which aimed to fix this issue https://github.com/react-native-share/react-native-share/pull/1126
However it only updated the `InstagramShare.java`, not the `InstagramStoriesShare.java`, hence this PR.


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
Use the `Share.shareSingle` function with the Instagram stories prop, along with a background image.

e.g. `await Share.shareSingle({social: Share.Social.INSTAGRAM_STORIES,
            backgroundImage: image})`

Before this fix you'll be greeted with a black screen
|Before|
|-|
|![before](https://user-images.githubusercontent.com/36278761/149234126-e4b92388-3b56-4fe8-aea2-7f6ff84cd245.gif)|


After this fix you'll see your image in a story
|After|
|-|
|![after](https://user-images.githubusercontent.com/36278761/149234025-fba7c6d8-d06b-4451-91ce-a24aeac81f7d.gif)|

