### PR TITLE
Use root locale when changing case in java

### DIFF
--- a/android/src/main/java/cl/json/RNShareModule.java
+++ b/android/src/main/java/cl/json/RNShareModule.java
@@ -14,6 +14,7 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.Callback;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import cl.json.social.EmailShare;
@@ -141,7 +142,7 @@ public class RNShareModule extends ReactContextBaseJavaModule implements Activit
     public Map<String, Object> getConstants() {
         Map<String, Object> constants = new HashMap<>();
         for (SHARES val : SHARES.values()) {
-            constants.put(val.toString().toUpperCase(), val.toString());
+            constants.put(val.toString().toUpperCase(Locale.ROOT), val.toString());
         }
         return constants;
     }


### PR DESCRIPTION
Not setting locale for language/country neutral operation may cause bug depending on the default locale.
See https://docs.oracle.com/javase/7/docs/api/java/util/Locale.html#ROOT

Note: I am just searching for toLowerCase() and toUppercase() in my project's dependencies and send the same PR, in order to potentially raise the awareness. Although I've seen the lack of explicit locale has caused issues for us, I am not sure if react-native-share is actually affected.

Example related issue: joltup/rn-fetch-blob#573

# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
