### PR TITLE
Bugfix/whatsapp empty conversation

### DIFF
--- a/android/src/main/java/cl/json/social/WhatsAppBusinessShare.java
+++ b/android/src/main/java/cl/json/social/WhatsAppBusinessShare.java
@@ -15,9 +15,9 @@ public class WhatsAppBusinessShare extends SingleShareIntent {
     private static final String PLAY_STORE_LINK = "market://details?id=com.whatsapp.w4b";
     
     private static final String START_CONVERSATION_CLASS = "com.whatsapp.Conversation";
-    private static final String SHARE_TO_CONVERSATION_CLASS = "com.whatsapp.ContactPicker";
-    
-    private static final int START_ACTIVITY_TIME_GAP_MS = 300;
+
+    // must be small enough so that both activities are triggered while the app is still on foreground
+    private static final int START_ACTIVITY_TIME_GAP_MS = 10; 
 
     public WhatsAppBusinessShare(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -27,21 +27,21 @@ public class WhatsAppBusinessShare extends SingleShareIntent {
         super.open(options);
         
         if (options.hasKey("whatsAppNumber")) {
-            // create an empty conversation in case it's not on contacts
-            this.getIntent().setComponent(new ComponentName(PACKAGE, START_CONVERSATION_CLASS)); 
-            this.openIntentChooser();
+            try {                
+                // create an empty conversation in case it's not on contacts
+                this.getIntent().setComponent(new ComponentName(PACKAGE, START_CONVERSATION_CLASS)); 
+                this.openIntentChooser();
 
-
-            // leave room for the conversation to be created
-            try {
+                // leave room for the conversation to be created
                 Thread.sleep(START_ACTIVITY_TIME_GAP_MS);   
-            } catch (InterruptedException ex) {
+
+            } catch (Exception ex) {
                 ex.printStackTrace();
             }
-
-            // share to conversation
-            this.getIntent().setComponent(new ComponentName(PACKAGE, SHARE_TO_CONVERSATION_CLASS)); 
         }
+
+        // restore default behavior to share to conversation
+        this.getIntent().setComponent(null); 
 
         //  extra params here
         this.openIntentChooser();

--- a/android/src/main/java/cl/json/social/WhatsAppShare.java
+++ b/android/src/main/java/cl/json/social/WhatsAppShare.java
@@ -15,9 +15,9 @@ public class WhatsAppShare extends SingleShareIntent {
     private static final String PLAY_STORE_LINK = "market://details?id=com.whatsapp";
         
     private static final String START_CONVERSATION_CLASS = "com.whatsapp.Conversation";
-    private static final String SHARE_TO_CONVERSATION_CLASS = "com.whatsapp.ContactPicker";
     
-    private static final int START_ACTIVITY_TIME_GAP_MS = 300;
+    // must be small enough so that both activities are triggered while the app is still on foreground
+    private static final int START_ACTIVITY_TIME_GAP_MS = 10; 
 
     public WhatsAppShare(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -27,21 +27,21 @@ public class WhatsAppShare extends SingleShareIntent {
         super.open(options);
         
         if (options.hasKey("whatsAppNumber")) {
-            // create an empty conversation in case it's not on contacts
-            this.getIntent().setComponent(new ComponentName(PACKAGE, START_CONVERSATION_CLASS)); 
-            this.openIntentChooser();
+            try {                
+                // create an empty conversation in case it's not on contacts
+                this.getIntent().setComponent(new ComponentName(PACKAGE, START_CONVERSATION_CLASS)); 
+                this.openIntentChooser();
 
-
-            // leave room for the conversation to be created
-            try {
+                // leave room for the conversation to be created
                 Thread.sleep(START_ACTIVITY_TIME_GAP_MS);   
-            } catch (InterruptedException ex) {
+
+            } catch (Exception ex) {
                 ex.printStackTrace();
             }
-
-            // share to conversation
-            this.getIntent().setComponent(new ComponentName(PACKAGE, SHARE_TO_CONVERSATION_CLASS)); 
         }
+
+        // restore default behavior to share to conversation
+        this.getIntent().setComponent(null); 
 
         //  extra params here
         this.openIntentChooser();


### PR DESCRIPTION
# Overview
Closes https://github.com/react-native-share/react-native-share/issues/1164. Related to the issue https://github.com/react-native-share/react-native-share/issues/952 and the changes on https://github.com/react-native-share/react-native-share/pull/1148

The previous fix had two issues: 

* the class name for sharing to a conversation changed after a WhatsApp update, so only empty conversations were created (logcat was reporting 'not found' errors). Changed the code to not depend on it (using `intent.setComponent(null)`).

* on android 10 and above an app cannot trigger an intent while it's on the background, so the second intent (sharing of the data) could be silently ignored. Reduced the time gap between triggering the conversation creation and the sharing of the data so that both are still triggered while the app is on the foreground. (This time gap is there just to enforce the order of the intents. This way works, but there could be better ways of achieving it.)

Tested on Android 9 and 11, WhatsApp and WhatsApp Business

# Test Plan
On the example app:
```js
  /**
   * This functions share a image passed using the
   * url param
   */
  const shareSingleImage = async () => {
    const shareOptions = {
      title: 'Share file',
      url: images.image1,
      failOnCancel: false,
      social: 'whatsapp', // or 'whatsappbusiness'
      whatsAppNumber:
        'Insert a number never contacted before here. Must include the country code, and not include symbols.',
    };

    try {
      const ShareResponse = await Share.shareSingle(shareOptions); // changed it to shareSingle();
      setResult(JSON.stringify(ShareResponse, null, 2));
    } catch (error) {
      console.log('Error =>', error);
      setResult('error: '.concat(getErrorString(error)));
    }
  };
```
