### PR TITLE
fix(ios): Replace initWithURLs with initForExportingURLs on iOS 15+

### DIFF
--- a/ios/RNShare.m
+++ b/ios/RNShare.m
@@ -246,10 +246,15 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options
             RCTLogError(@"No `urls` to save in Files");
             return;
         }
-        if (@available(iOS 11.0, *)) {
+        if (@available(iOS 11.0, macCatalyst 13.1, *)) {
             resolveBlock = successCallback;
             rejectBlock = failureCallback;
-            UIDocumentPickerViewController *documentPicker = [[UIDocumentPickerViewController alloc] initWithURLs:urls inMode:UIDocumentPickerModeExportToService];
+            UIDocumentPickerViewController *documentPicker = nil;
+            if (@available(iOS 15.0, macCatalyst 15.0, *)) {
+                documentPicker = [[UIDocumentPickerViewController alloc] initForExportingURLs:urls asCopy:YES];
+            } else {
+                documentPicker = [[UIDocumentPickerViewController alloc] initWithURLs:urls inMode:UIDocumentPickerModeExportToService];
+            }
             [documentPicker setDelegate:self];
             [controller presentViewController:documentPicker animated:YES completion:nil];
             return;


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

[initWithURLs:inMode](https://developer.apple.com/documentation/uikit/uidocumentpickerviewcontroller/2921628-initwithurls?language=objc)  deprecated on iOS 15+. Use [initForExportingURLs](https://developer.apple.com/documentation/uikit/uidocumentpickerviewcontroller/3566731-initforexportingurls?language=objc) instead on iOS 15+.

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
**Device Test:**

iOS15+:
<img width="320" src="https://user-images.githubusercontent.com/37284154/163406642-2cb6effa-dc9e-4ec1-a03e-e362cccee483.png"  />

Mac Catalyst:
<img width="320" src="https://user-images.githubusercontent.com/37284154/163496997-bc92a1bf-9c11-47ef-a1c0-89d21f5899b1.png"  />

