### PR TITLE
fix(ios): custom title got over written by meta data

### DIFF
--- a/ios/RNShareActivityItemSource.m
+++ b/ios/RNShareActivityItemSource.m
@@ -66,7 +66,9 @@
             } else {
                 self->linkMetadata.originalURL = metadata.originalURL;
                 self->linkMetadata.URL = metadata.URL;
-                // self->linkMetadata.title = metadata.title;
+                if(!self->linkMetadata.title) {
+                    self->linkMetadata.title = metadata.title;
+                }
                 self->linkMetadata.imageProvider = metadata.imageProvider;
                 if (self->linkMetadata.imageProvider) {
                     self->linkMetadata.iconProvider = self->linkMetadata.imageProvider;

--- a/ios/RNShareActivityItemSource.m
+++ b/ios/RNShareActivityItemSource.m
@@ -66,7 +66,7 @@
             } else {
                 self->linkMetadata.originalURL = metadata.originalURL;
                 self->linkMetadata.URL = metadata.URL;
-                self->linkMetadata.title = metadata.title;
+                // self->linkMetadata.title = metadata.title;
                 self->linkMetadata.imageProvider = metadata.imageProvider;
                 if (self->linkMetadata.imageProvider) {
                     self->linkMetadata.iconProvider = self->linkMetadata.imageProvider;


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

The title which user has provided in the linkMetaData options should not be overwritten by metadata from url, unless title is not specified by the user.

# Test Plan

Test Case 1:

Pass the title prop in LinkMetaData options, while sharing the title passed should be present even if the title in metadata is different.

Test Case 2:

If title is not specified in the LinkMetaData options, while sharing the title must be taken from metadata in URL

