### PR TITLE
Feature/new task

### DIFF
--- a/android/src/main/java/cl/json/social/ShareIntent.java
+++ b/android/src/main/java/cl/json/social/ShareIntent.java
@@ -98,6 +98,10 @@ public abstract class ShareIntent {
     public void open(ReadableMap options) throws ActivityNotFoundException {
         this.options = options;
 
+        if (ShareIntent.hasValidKey("isNewTask", options) && options.getBoolean("isNewTask")) {
+            this.getIntent().addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        }
+
         if (ShareIntent.hasValidKey("subject", options)) {
             this.getIntent().putExtra(Intent.EXTRA_SUBJECT, options.getString("subject"));
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,7 @@ export interface ShareOptions {
   filenames?: string[];
   saveToFiles?: boolean;
   activityItemSources?: ActivityItemSource[];
+  isNewTask: boolean;
 }
 
 export type ActivityType =

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,7 +101,7 @@ export interface ShareOptions {
   filenames?: string[];
   saveToFiles?: boolean;
   activityItemSources?: ActivityItemSource[];
-  isNewTask: boolean;
+  isNewTask?: boolean;
 }
 
 export type ActivityType =

--- a/website/docs/share-open.mdx
+++ b/website/docs/share-open.mdx
@@ -51,6 +51,7 @@ You can customize the call to `Share.open` passing the following parameters:
 | filenames             | Array[string] | Array of filename for base64 urls array in Android                                                                                                             | ✅       | ✅      | 🚫  | ❓      |
 | activityItemSources   | Array[Object] | Array of activity item sources. Each items should conform to [ActivityItemSource](#activityitemsource) specification. [Example](#example-activityitemsources). | ✅       | 🚫      | ✅  | ❓      |
 | useInternalStorage    |    boolean    | Store the temporary file in the internal storage cache (Android only)                                                                                          | ✅       | ✅      | 🚫  | 🚫      |
+| isNewTask             |    boolean    | Open intent as a new task. "failOnCancel" will not work.                                                                                                       | ✅       | ✅      | 🚫  | ❓      |
 
 ## Sharing a base64 file format
 


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

In Android, the external app for sharing opened within the current app. I needed to split these so the user can return easily to the app that initiated the Share action or the new opened app.


