### PR TITLE
Fix: remove old style double-quote imports

### DIFF
--- a/ios/EmailShare.h
+++ b/ios/EmailShare.h
@@ -8,46 +8,16 @@
 
 
 #import <UIKit/UIKit.h>
-// import RCTConvert
-#if __has_include(<React/RCTConvert.h>)
+// import RCTConvertttt
 #import <React/RCTConvert.h>
-#elif __has_include("RCTConvert.h")
-#import "RCTConvert.h"
-#else
-#import "React/RCTConvert.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTBridge
-#if __has_include(<React/RCTBridge.h>)
 #import <React/RCTBridge.h>
-#elif __has_include("RCTBridge.h")
-#import "RCTBridge.h"
-#else
-#import "React/RCTBridge.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTUIManager
-#if __has_include(<React/RCTUIManager.h>)
 #import <React/RCTUIManager.h>
-#elif __has_include("RCTUIManager.h")
-#import "RCTUIManager.h"
-#else
-#import "React/RCTUIManager.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTLog
-#if __has_include(<React/RCTLog.h>)
 #import <React/RCTLog.h>
-#elif __has_include("RCTLog.h")
-#import "RCTLog.h"
-#else
-#import "React/RCTLog.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTUtils
-#if __has_include(<React/RCTUtils.h>)
 #import <React/RCTUtils.h>
-#elif __has_include("RCTUtils.h")
-#import "RCTUtils.h"
-#else
-#import "React/RCTUtils.h"   // Required when used as a Pod in a Swift project
-#endif
 #import <MessageUI/MessageUI.h>
 @interface EmailShare : NSObject <MFMailComposeViewControllerDelegate>
 

--- a/ios/FacebookStories.h
+++ b/ios/FacebookStories.h
@@ -9,45 +9,15 @@
 
 #import <UIKit/UIKit.h>
 // import RCTConvert
-#if __has_include(<React/RCTConvert.h>)
 #import <React/RCTConvert.h>
-#elif __has_include("RCTConvert.h")
-#import "RCTConvert.h"
-#else
-#import "React/RCTConvert.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTBridge
-#if __has_include(<React/RCTBridge.h>)
 #import <React/RCTBridge.h>
-#elif __has_include("RCTBridge.h")
-#import "RCTBridge.h"
-#else
-#import "React/RCTBridge.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTUIManager
-#if __has_include(<React/RCTUIManager.h>)
 #import <React/RCTUIManager.h>
-#elif __has_include("RCTUIManager.h")
-#import "RCTUIManager.h"
-#else
-#import "React/RCTUIManager.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTLog
-#if __has_include(<React/RCTLog.h>)
 #import <React/RCTLog.h>
-#elif __has_include("RCTLog.h")
-#import "RCTLog.h"
-#else
-#import "React/RCTLog.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTUtils
-#if __has_include(<React/RCTUtils.h>)
 #import <React/RCTUtils.h>
-#elif __has_include("RCTUtils.h")
-#import "RCTUtils.h"
-#else
-#import "React/RCTUtils.h"   // Required when used as a Pod in a Swift project
-#endif
 @interface FacebookStories : NSObject <RCTBridgeModule>
 
 - (void *) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback;

--- a/ios/FacebookStories.m
+++ b/ios/FacebookStories.m
@@ -8,13 +8,7 @@
 //
 
 // import RCTLog
-#if __has_include(<React/RCTLog.h>)
 #import <React/RCTLog.h>
-#elif __has_include("RCTLog.h")
-#import "RCTLog.h"
-#else
-#import "React/RCTLog.h"   // Required when used as a Pod in a Swift project
-#endif
 
 #import "FacebookStories.h"
 

--- a/ios/GenericShare.h
+++ b/ios/GenericShare.h
@@ -10,45 +10,15 @@
 #import <Social/Social.h>
 #import <UIKit/UIKit.h>
 // import RCTConvert
-#if __has_include(<React/RCTConvert.h>)
 #import <React/RCTConvert.h>
-#elif __has_include("RCTConvert.h")
-#import "RCTConvert.h"
-#else
-#import "React/RCTConvert.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTBridge
-#if __has_include(<React/RCTBridge.h>)
 #import <React/RCTBridge.h>
-#elif __has_include("RCTBridge.h")
-#import "RCTBridge.h"
-#else
-#import "React/RCTBridge.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTUIManager
-#if __has_include(<React/RCTUIManager.h>)
 #import <React/RCTUIManager.h>
-#elif __has_include("RCTUIManager.h")
-#import "RCTUIManager.h"
-#else
-#import "React/RCTUIManager.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTLog
-#if __has_include(<React/RCTLog.h>)
 #import <React/RCTLog.h>
-#elif __has_include("RCTLog.h")
-#import "RCTLog.h"
-#else
-#import "React/RCTLog.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTUtils
-#if __has_include(<React/RCTUtils.h>)
 #import <React/RCTUtils.h>
-#elif __has_include("RCTUtils.h")
-#import "RCTUtils.h"
-#else
-#import "React/RCTUtils.h"   // Required when used as a Pod in a Swift project
-#endif
 @interface GenericShare : NSObject <RCTBridgeModule>
 
 - (void) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback serviceType:(NSString*)serviceType

--- a/ios/GooglePlusShare.h
+++ b/ios/GooglePlusShare.h
@@ -7,45 +7,15 @@
 //
 #import <UIKit/UIKit.h>
 // import RCTConvert
-#if __has_include(<React/RCTConvert.h>)
 #import <React/RCTConvert.h>
-#elif __has_include("RCTConvert.h")
-#import "RCTConvert.h"
-#else
-#import "React/RCTConvert.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTBridge
-#if __has_include(<React/RCTBridge.h>)
 #import <React/RCTBridge.h>
-#elif __has_include("RCTBridge.h")
-#import "RCTBridge.h"
-#else
-#import "React/RCTBridge.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTUIManager
-#if __has_include(<React/RCTUIManager.h>)
 #import <React/RCTUIManager.h>
-#elif __has_include("RCTUIManager.h")
-#import "RCTUIManager.h"
-#else
-#import "React/RCTUIManager.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTLog
-#if __has_include(<React/RCTLog.h>)
 #import <React/RCTLog.h>
-#elif __has_include("RCTLog.h")
-#import "RCTLog.h"
-#else
-#import "React/RCTLog.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTUtils
-#if __has_include(<React/RCTUtils.h>)
 #import <React/RCTUtils.h>
-#elif __has_include("RCTUtils.h")
-#import "RCTUtils.h"
-#else
-#import "React/RCTUtils.h"   // Required when used as a Pod in a Swift project
-#endif
 @interface GooglePlusShare : NSObject <RCTBridgeModule>
 
 - (void) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback;

--- a/ios/InstagramShare.h
+++ b/ios/InstagramShare.h
@@ -7,45 +7,15 @@
 
 #import <UIKit/UIKit.h>
 // import RCTConvert
-#if __has_include(<React/RCTConvert.h>)
 #import <React/RCTConvert.h>
-#elif __has_include("RCTConvert.h")
-#import "RCTConvert.h"
-#else
-#import "React/RCTConvert.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTBridge
-#if __has_include(<React/RCTBridge.h>)
 #import <React/RCTBridge.h>
-#elif __has_include("RCTBridge.h")
-#import "RCTBridge.h"
-#else
-#import "React/RCTBridge.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTUIManager
-#if __has_include(<React/RCTUIManager.h>)
 #import <React/RCTUIManager.h>
-#elif __has_include("RCTUIManager.h")
-#import "RCTUIManager.h"
-#else
-#import "React/RCTUIManager.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTLog
-#if __has_include(<React/RCTLog.h>)
 #import <React/RCTLog.h>
-#elif __has_include("RCTLog.h")
-#import "RCTLog.h"
-#else
-#import "React/RCTLog.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTUtils
-#if __has_include(<React/RCTUtils.h>)
 #import <React/RCTUtils.h>
-#elif __has_include("RCTUtils.h")
-#import "RCTUtils.h"
-#else
-#import "React/RCTUtils.h"   // Required when used as a Pod in a Swift project
-#endif
 @interface InstagramShare : NSObject <RCTBridgeModule>
 
 - (void) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback;

--- a/ios/InstagramStories.h
+++ b/ios/InstagramStories.h
@@ -8,45 +8,15 @@
 
 #import <UIKit/UIKit.h>
 // import RCTConvert
-#if __has_include(<React/RCTConvert.h>)
 #import <React/RCTConvert.h>
-#elif __has_include("RCTConvert.h")
-#import "RCTConvert.h"
-#else
-#import "React/RCTConvert.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTBridge
-#if __has_include(<React/RCTBridge.h>)
 #import <React/RCTBridge.h>
-#elif __has_include("RCTBridge.h")
-#import "RCTBridge.h"
-#else
-#import "React/RCTBridge.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTUIManager
-#if __has_include(<React/RCTUIManager.h>)
 #import <React/RCTUIManager.h>
-#elif __has_include("RCTUIManager.h")
-#import "RCTUIManager.h"
-#else
-#import "React/RCTUIManager.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTLog
-#if __has_include(<React/RCTLog.h>)
 #import <React/RCTLog.h>
-#elif __has_include("RCTLog.h")
-#import "RCTLog.h"
-#else
-#import "React/RCTLog.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTUtils
-#if __has_include(<React/RCTUtils.h>)
 #import <React/RCTUtils.h>
-#elif __has_include("RCTUtils.h")
-#import "RCTUtils.h"
-#else
-#import "React/RCTUtils.h"   // Required when used as a Pod in a Swift project
-#endif
 @interface InstagramStories : NSObject <RCTBridgeModule>
 
 - (void *) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback;

--- a/ios/InstagramStories.m
+++ b/ios/InstagramStories.m
@@ -7,13 +7,7 @@
 //
 
 // import RCTLog
-#if __has_include(<React/RCTLog.h>)
 #import <React/RCTLog.h>
-#elif __has_include("RCTLog.h")
-#import "RCTLog.h"
-#else
-#import "React/RCTLog.h"   // Required when used as a Pod in a Swift project
-#endif
 
 #import "InstagramStories.h"
 

--- a/ios/RNShare.h
+++ b/ios/RNShare.h
@@ -1,12 +1,6 @@
 @import UIKit;
 // import RCTBridgeModule
-#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
-#elif __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
-#import "React/RCTBridgeModule.h"   // Required when used as a Pod in a Swift project
-#endif
 
 @interface RNShare : NSObject <RCTBridgeModule, UIDocumentPickerDelegate>
 

--- a/ios/RNShare.m
+++ b/ios/RNShare.m
@@ -1,45 +1,15 @@
 #import <MessageUI/MessageUI.h>
 #import "RNShare.h"
 // import RCTConvert
-#if __has_include(<React/RCTConvert.h>)
 #import <React/RCTConvert.h>
-#elif __has_include("RCTConvert.h")
-#import "RCTConvert.h"
-#else
-#import "React/RCTConvert.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTLog
-#if __has_include(<React/RCTLog.h>)
 #import <React/RCTLog.h>
-#elif __has_include("RCTLog.h")
-#import "RCTLog.h"
-#else
-#import "React/RCTLog.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTUtils
-#if __has_include(<React/RCTUtils.h>)
 #import <React/RCTUtils.h>
-#elif __has_include("RCTUtils.h")
-#import "RCTUtils.h"
-#else
-#import "React/RCTUtils.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTBridge
-#if __has_include(<React/RCTBridge.h>)
 #import <React/RCTBridge.h>
-#elif __has_include("RCTBridge.h")
-#import "RCTBridge.h"
-#else
-#import "React/RCTBridge.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTBridge
-#if __has_include(<React/RCTUIManager.h>)
 #import <React/RCTUIManager.h>
-#elif __has_include("RCTUIManager.h")
-#import "RCTUIManager.h"
-#else
-#import "React/RCTUIManager.h"   // Required when used as a Pod in a Swift project
-#endif
 #import "GenericShare.h"
 #import "WhatsAppShare.h"
 #import "InstagramShare.h"

--- a/ios/RNShareActivityItemSource.m
+++ b/ios/RNShareActivityItemSource.m
@@ -5,22 +5,10 @@
 #endif
 
 // import RCTBridgeModule
-#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
-#elif __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
-#import "React/RCTBridgeModule.h"   // Required when used as a Pod in a Swift project
-#endif
 
 // import RCTConvert
-#if __has_include(<React/RCTConvert.h>)
 #import <React/RCTConvert.h>
-#elif __has_include("RCTConvert.h")
-#import "RCTConvert.h"
-#else
-#import "React/RCTConvert.h"   // Required when used as a Pod in a Swift project
-#endif
 
 @implementation RNShareActivityItemSource {
     id placeholderItem;

--- a/ios/TelegramShare.h
+++ b/ios/TelegramShare.h
@@ -7,45 +7,15 @@
 
 #import <UIKit/UIKit.h>
 // import RCTConvert
-#if __has_include(<React/RCTConvert.h>)
 #import <React/RCTConvert.h>
-#elif __has_include("RCTConvert.h")
-#import "RCTConvert.h"
-#else
-#import "React/RCTConvert.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTBridge
-#if __has_include(<React/RCTBridge.h>)
 #import <React/RCTBridge.h>
-#elif __has_include("RCTBridge.h")
-#import "RCTBridge.h"
-#else
-#import "React/RCTBridge.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTUIManager
-#if __has_include(<React/RCTUIManager.h>)
 #import <React/RCTUIManager.h>
-#elif __has_include("RCTUIManager.h")
-#import "RCTUIManager.h"
-#else
-#import "React/RCTUIManager.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTLog
-#if __has_include(<React/RCTLog.h>)
 #import <React/RCTLog.h>
-#elif __has_include("RCTLog.h")
-#import "RCTLog.h"
-#else
-#import "React/RCTLog.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTUtils
-#if __has_include(<React/RCTUtils.h>)
 #import <React/RCTUtils.h>
-#elif __has_include("RCTUtils.h")
-#import "RCTUtils.h"
-#else
-#import "React/RCTUtils.h"   // Required when used as a Pod in a Swift project
-#endif
 @interface TelegramShare : NSObject <RCTBridgeModule>
 
 - (void) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback;

--- a/ios/WhatsAppShare.h
+++ b/ios/WhatsAppShare.h
@@ -8,45 +8,15 @@
 
 #import <UIKit/UIKit.h>
 // import RCTConvert
-#if __has_include(<React/RCTConvert.h>)
 #import <React/RCTConvert.h>
-#elif __has_include("RCTConvert.h")
-#import "RCTConvert.h"
-#else
-#import "React/RCTConvert.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTBridge
-#if __has_include(<React/RCTBridge.h>)
 #import <React/RCTBridge.h>
-#elif __has_include("RCTBridge.h")
-#import "RCTBridge.h"
-#else
-#import "React/RCTBridge.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTUIManager
-#if __has_include(<React/RCTUIManager.h>)
 #import <React/RCTUIManager.h>
-#elif __has_include("RCTUIManager.h")
-#import "RCTUIManager.h"
-#else
-#import "React/RCTUIManager.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTLog
-#if __has_include(<React/RCTLog.h>)
 #import <React/RCTLog.h>
-#elif __has_include("RCTLog.h")
-#import "RCTLog.h"
-#else
-#import "React/RCTLog.h"   // Required when used as a Pod in a Swift project
-#endif
 // import RCTUtils
-#if __has_include(<React/RCTUtils.h>)
 #import <React/RCTUtils.h>
-#elif __has_include("RCTUtils.h")
-#import "RCTUtils.h"
-#else
-#import "React/RCTUtils.h"   // Required when used as a Pod in a Swift project
-#endif
 @interface WhatsAppShare : NSObject <RCTBridgeModule,UIDocumentInteractionControllerDelegate>
 
 - (void) shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback;


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Hey folks, 

This PR closes https://github.com/react-native-share/react-native-share/issues/1197. It seems that in Expo SDK 44, the Expo team made some changes to `React-Core.podspec`, which now break on the old style double-quote imports. [Here is a comment from an issue that very precisely describes the changes and their implications](https://github.com/expo/expo/issues/15622#issuecomment-997225774).

I haven't really written Objective-C since like 2012, so in order to find my way around, I modeled the changes after this `patch-package` diff for a different package: https://github.com/expo/expo/issues/15622#issuecomment-997141629. Mostly I swapped out the conditional imports with the double-quoted `RCT` classes. 

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Once I made my changes, I started the [example application](https://react-native-share.github.io/react-native-share/docs/contributing#using-the-example-app). It built fine for iOS and the buttons fired. I got some errors in the console when I tried things like sharing to Instagram or Telegram, but mostly these errors said things like "not installed", and I'm assuming this is because I didn't have the corresponding apps installed on that particular simulator. 

To check if it was my changes or missing apps on the simulator, I ran the example app from the `main` branch, and I saw the same behavior: IG share and FB share opened an empty Safari tab. 

If there's a better way for me to set up a test environment, will you folks let me know? I didn't see much else in the contribution guide. 
