### PR TITLE
fix(ios): use https in place of https for facebook/instagram/whatsapp

### DIFF
--- a/ios/FacebookStories.m
+++ b/ios/FacebookStories.m
@@ -83,7 +83,7 @@ RCT_EXPORT_MODULE();
 
 - (void)fallbackFacebook {
     // Cannot open facebook
-    NSString *stringURL = @"http://itunes.apple.com/app/facebook/id284882215";
+    NSString *stringURL = @"https://itunes.apple.com/app/facebook/id284882215";
     NSURL *url = [NSURL URLWithString:stringURL];
     [[UIApplication sharedApplication] openURL:url];
 

--- a/ios/InstagramStories.m
+++ b/ios/InstagramStories.m
@@ -80,7 +80,7 @@ RCT_EXPORT_MODULE();
 
 - (void)fallbackInstagram {
     // Cannot open instagram
-    NSString *stringURL = @"http://itunes.apple.com/app/instagram/id389801252";
+    NSString *stringURL = @"https://itunes.apple.com/app/instagram/id389801252";
     NSURL *url = [NSURL URLWithString:stringURL];
     [[UIApplication sharedApplication] openURL:url];
 

--- a/ios/WhatsAppShare.m
+++ b/ios/WhatsAppShare.m
@@ -26,7 +26,7 @@ RCT_EXPORT_MODULE();
             NSLog(@"WhatsApp installed");
         } else {
             // Cannot open whatsapp
-            NSString *stringURL = @"http://itunes.apple.com/app/whatsapp-messenger/id310633997";
+            NSString *stringURL = @"https://itunes.apple.com/app/whatsapp-messenger/id310633997";
             NSURL *url = [NSURL URLWithString:stringURL];
             [[UIApplication sharedApplication] openURL:url];
             


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
simple change to the URL schema of Facebook, Instagram, and Whatsapp

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
Manually tested on **Pixel_4_API_30 simulator**.
_PS: No physical iPhone to test on_