### PR TITLE
build(deps): use node v16 in circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,9 @@ commands:
 
 jobs:
   install-dependencies:
-    executor: react-native/linux_js
+    executor:
+      name: react-native/linux_js
+      node_version: '16'
     working_directory: ~/app
     steps:
       - checkout


### PR DESCRIPTION
their default is still 12, semantic release requires 16

# Test Plan

Not sure exactly how to test this - hopefully CircleCI runs it when I propose this change?

It'd built directly from docs here:
https://circleci.com/developer/orbs/orb/react-native-community/react-native