### PR TITLE
ci(mac): setting default node version to 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,8 @@ jobs:
     working_directory: ~/app
     steps:
       - checkout
-      - react-native/setup_macos_executor
+      - react-native/setup_macos_executor:
+          node_version: '16'
       - run: yarn install --frozen-lockfile --non-interactive
       - react-native/pod_install:
           pod_install_directory: ./example/ios


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
This should fix the MacOs build error. Enabling us to merge #1217


# Test Plan
I hope CircleCI will build and everything is going to pass. 😅 
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
