### PR TITLE
ci(node): setting publish version to 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,9 @@ jobs:
           device: iPhone 11
 
   publish-version:
-    executor: react-native/linux_js
+    executor: 
+      name: react-native/linux_js
+      node_version: '14'
     working_directory: ~/app
     steps:
       - checkout-attach-workspace


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
Setting node version to 14, in order to properly publish new packages due to #1217 bumping semantic-release

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
Run at CircleCI 🚀 