### PR TITLE
fix(typing): remove "method" typing for facebook stories share

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -78,7 +78,6 @@ export interface InstagramStoriesShareSingleOptions extends BaseSocialStoriesSha
 
 export interface FacebookStoriesShareSingleOptions extends BaseSocialStoriesShareSingleOptions {
   social: Social.FacebookStories;
-  method: Exclude<ShareAsset, ShareAsset.BackgroundVideo>;
   appId: string;
 }
 


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
Removed the `method` field from FacebookStoriesShareSingleOptions interface. From my understanding, the `method` field is no longer used since #1115, but the typing has not been updated and therefore causes linting warnings/errors when using TypeScript.

