### PR TITLE
fix(android): facebook stories

### DIFF
--- a/android/src/main/java/cl/json/social/FacebookStoriesShare.java
+++ b/android/src/main/java/cl/json/social/FacebookStoriesShare.java
@@ -98,14 +98,14 @@ public class FacebookStoriesShare extends SingleShareIntent {
                 backgroundFileName = options.getString("backgroundVideo");
             }
 
-            ShareFile backgroundAsset = new ShareFile(backgroundFileName, "background", useInternalStorage, this.reactContext);
+            ShareFile backgroundAsset = new ShareFile(backgroundFileName, "image/jpeg", "background", useInternalStorage, this.reactContext);
 
             this.intent.setDataAndType(backgroundAsset.getURI(), backgroundAsset.getType());
             this.intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         }
 
         if (this.hasValidKey("stickerImage", options)) {
-            ShareFile stickerAsset = new ShareFile(options.getString("stickerImage"), "sticker", useInternalStorage, this.reactContext);
+            ShareFile stickerAsset = new ShareFile(options.getString("stickerImage"), "image/png", "sticker", useInternalStorage, this.reactContext);
 
             if (!hasBackgroundAsset) {
                 this.intent.setType("image/*");


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
As said in [this issue](https://github.com/react-native-share/react-native-share/issues/1196), Facebook Stories is not working on Android, @steo-ml shows a fix [here](https://github.com/react-native-share/react-native-share/issues/1196#issuecomment-1120639001).
The image in Facebook Stories is using `ShareFile` constructor without the image type, some problem is happening to get the image type (probably a future fix on `ShareFile`), and the temporary fix is to use the constructor which you can send the type.


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
Run Android app, and try to share Facebook Stories using a background image or sticker image