### PR TITLE
Change type of excludedActivityTypes

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -95,7 +95,7 @@ export interface ShareOptions {
   subject?: string;
   email?: string;
   recipient?: string;
-  excludedActivityTypes?: ActivityType[];
+  excludedActivityTypes?: ActivityType[] | string[];
   failOnCancel?: boolean;
   showAppsToView?: boolean;
   filename?: string;


### PR DESCRIPTION
fix #1241 (excludedActivityTypes allow specific android package names but TypeScript interface don't)

![image](https://user-images.githubusercontent.com/28831375/176799224-94c71d71-32ae-4aa5-a391-3b11997e123a.png)

https://github.com/react-native-share/react-native-share/blob/3038dd4d3b315eaad08e259528ce176a0afa85bd/android/src/main/java/cl/json/social/ShareIntent.java#L62