### PR TITLE
fix(android): add background type for instagram video story sharing

### DIFF
--- a/android/src/main/java/cl/json/social/InstagramStoriesShare.java
+++ b/android/src/main/java/cl/json/social/InstagramStoriesShare.java
@@ -86,14 +86,16 @@ public class InstagramStoriesShare extends SingleShareIntent {
 
         if (hasBackgroundAsset) {
             String backgroundFileName = "";
+            String backgroundType = "image/jpeg";
 
             if (this.hasValidKey("backgroundImage", options)) {
                 backgroundFileName = options.getString("backgroundImage");
             } else if (this.hasValidKey("backgroundVideo", options)) {
                 backgroundFileName = options.getString("backgroundVideo");
+                backgroundType = "video/*";
             }
 
-            ShareFile backgroundAsset = new ShareFile(backgroundFileName, "image/jpeg", "background", useInternalStorage, this.reactContext);
+            ShareFile backgroundAsset = new ShareFile(backgroundFileName, backgroundType, "background", useInternalStorage, this.reactContext);
 
             this.intent.setDataAndType(backgroundAsset.getURI(), backgroundAsset.getType());
             this.intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);


### PR DESCRIPTION
# Overview
While sharing an Instagram story with **backgroundVideo** option, iOS works fine with remote urls. But on Android you have to download and cache it, then use the local file path to pass IG. But currently it doesn't work, because we're giving file type "image/jpeg" in every scenario.
I've changed the type according to if statement that already exists. And default type is still "image/jpeg".


# Test Plan
I tested the fix on Samsung S7(Android 8.0-API-26).
I'm already using the fix with [patch-package](https://www.npmjs.com/package/patch-package) and I'm adding the changes here so you can use and test it right away:
**react-native-share+7.6.4.patch**
```
diff --git a/node_modules/react-native-share/android/src/main/java/cl/json/social/InstagramStoriesShare.java b/node_modules/react-native-share/android/src/main/java/cl/json/social/InstagramStoriesShare.java
index f71405d..6dc7a17 100644
--- a/node_modules/react-native-share/android/src/main/java/cl/json/social/InstagramStoriesShare.java
+++ b/node_modules/react-native-share/android/src/main/java/cl/json/social/InstagramStoriesShare.java
@@ -86,14 +86,16 @@ public class InstagramStoriesShare extends SingleShareIntent {
 
         if (hasBackgroundAsset) {
             String backgroundFileName = "";
+            String backgroundType = "image/jpeg";
 
             if (this.hasValidKey("backgroundImage", options)) {
                 backgroundFileName = options.getString("backgroundImage");
             } else if (this.hasValidKey("backgroundVideo", options)) {
                 backgroundFileName = options.getString("backgroundVideo");
+                backgroundType = "video/*";
             }
 
-            ShareFile backgroundAsset = new ShareFile(backgroundFileName, "image/jpeg", "background", useInternalStorage, this.reactContext);
+            ShareFile backgroundAsset = new ShareFile(backgroundFileName, backgroundType, "background", useInternalStorage, this.reactContext);
 
             this.intent.setDataAndType(backgroundAsset.getURI(), backgroundAsset.getType());
             this.intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
```

Here is how I use the shareSingle():
```
import RNFetchBlob from 'rn-fetch-blob';
import Share from 'react-native-share';
/* ... */
            const share = (videoUri) => {
              Share.shareSingle({
                backgroundVideo: videoUri,
                stickerImage: igImage, // You can use it with a sticker image too
                backgroundBottomColor: '#121212',
                backgroundTopColor: '#6AA4E0',
                social: Share.Social.INSTAGRAM_STORIES,
                title: 'Join Us',
              });
            };
            if (Platform.OS === 'android') {
              const cache = await RNFetchBlob.config({
                fileCache: true,
                appendExt: 'mp4',
              }).fetch('GET', igVideo, {});
              share('file://' + cache.path());
            } else {
              share(igVideo);
            }
```