### PR TITLE
fix(ios): successCallback usages

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -68,6 +68,7 @@ const App = () => {
     // the share response. If the user cancels, etc.
     try {
       const ShareResponse = await Share.open(shareOptions);
+      console.log('Result =>', ShareResponse);
       setResult(JSON.stringify(ShareResponse, null, 2));
     } catch (error) {
       console.log('Error =>', error);
@@ -90,6 +91,7 @@ const App = () => {
 
     try {
       const ShareResponse = await Share.open(shareOptions);
+      console.log('Result =>', ShareResponse);
       setResult(JSON.stringify(ShareResponse, null, 2));
     } catch (error) {
       console.log('Error =>', error);
@@ -108,6 +110,7 @@ const App = () => {
 
     try {
       const ShareResponse = await Share.shareSingle(shareOptions);
+      console.log('Response =>', ShareResponse);
       setResult(JSON.stringify(ShareResponse, null, 2));
     } catch (error) {
       console.log('Error =>', error);
@@ -128,6 +131,7 @@ const App = () => {
 
     try {
       const ShareResponse = await Share.open(shareOptions);
+      console.log('Result =>', ShareResponse);
       setResult(JSON.stringify(ShareResponse, null, 2));
     } catch (error) {
       console.log('Error =>', error);
@@ -151,6 +155,7 @@ const App = () => {
     // the share response. If the user cancels, etc.
     try {
       const ShareResponse = await Share.open(shareOptions);
+      console.log('Result =>', ShareResponse);
       setResult(JSON.stringify(ShareResponse, null, 2));
     } catch (error) {
       console.log('Error =>', error);
@@ -167,6 +172,7 @@ const App = () => {
 
     try {
       const ShareResponse = await Share.shareSingle(shareOptions);
+      console.log('Response =>', ShareResponse);
       setResult(JSON.stringify(ShareResponse, null, 2));
     } catch (error) {
       console.log('Error =>', error);
@@ -184,6 +190,7 @@ const App = () => {
 
     try {
       const ShareResponse = await Share.shareSingle(shareOptions);
+      console.log('Response =>', ShareResponse);
       setResult(JSON.stringify(ShareResponse, null, 2));
     } catch (error) {
       console.log('Error =>', error);
@@ -201,6 +208,7 @@ const App = () => {
 
     try {
       const ShareResponse = await Share.shareSingle(shareOptions);
+      console.log('Response =>', ShareResponse);
       setResult(JSON.stringify(ShareResponse, null, 2));
     } catch (error) {
       console.log('Error =>', error);
@@ -217,6 +225,41 @@ const App = () => {
 
     try {
       const ShareResponse = await Share.shareSingle(shareOptions);
+      console.log('Response =>', ShareResponse);
+      setResult(JSON.stringify(ShareResponse, null, 2));
+    } catch (error) {
+      console.log('Error =>', error);
+      setResult('error: '.concat(getErrorString(error)));
+    }
+  };
+
+  const shareToGooglePlus = async () => {
+    const shareOptions = {
+      message: 'Example Google Plus',
+      url: 'https://google.com',
+      social: Share.Social.GOOGLEPLUS,
+    };
+
+    try {
+      const ShareResponse = await Share.shareSingle(shareOptions);
+      console.log('Response =>', ShareResponse);
+      setResult(JSON.stringify(ShareResponse, null, 2));
+    } catch (error) {
+      console.log('Error =>', error);
+      setResult('error: '.concat(getErrorString(error)));
+    }
+  };
+
+  const shareToWhatsApp = async () => {
+    const shareOptions = {
+      message: 'Example WhatsApp',
+      url: 'https://google.com',
+      social: Share.Social.WHATSAPP,
+    };
+
+    try {
+      const ShareResponse = await Share.shareSingle(shareOptions);
+      console.log('Response =>', ShareResponse);
       setResult(JSON.stringify(ShareResponse, null, 2));
     } catch (error) {
       console.log('Error =>', error);
@@ -232,6 +275,7 @@ const App = () => {
 
     try {
       const ShareResponse = await Share.open(shareOptions);
+      console.log('Result =>', ShareResponse);
       setResult(JSON.stringify(ShareResponse, null, 2));
     } catch (error) {
       console.log('sharePdfBase64 Error =>', error);
@@ -260,6 +304,12 @@ const App = () => {
         </View>
         <View style={styles.button}>
           <Button onPress={shareToTelegram} title="Share to Telegram" />
+        </View>
+        <View style={styles.button}>
+          <Button onPress={shareToGooglePlus} title="Share to Google Plus" />
+        </View>
+        <View style={styles.button}>
+          <Button onPress={shareToWhatsApp} title="Share to WhatsApp" />
         </View>
         <View style={styles.button}>
           <Button onPress={shareEmailImages} title="Share to Email" />

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -337,7 +337,7 @@ PODS:
     - React-jsi (= 0.66.4)
     - React-logger (= 0.66.4)
     - React-perflogger (= 0.66.4)
-  - RNShare (7.3.3):
+  - RNShare (7.7.0):
     - React-Core
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
@@ -483,7 +483,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: cde416483dac037923206447da6e1454df403714
+  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: e5569e42a1c79ca00521846c223173a57aca1fe1
   FBReactNativeSpec: fe08c1cd7e2e205718d77ad14b34957cce949b58
   Flipper: 30e8eeeed6abdc98edaf32af0cda2f198be4b733
@@ -496,7 +496,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: d8d346844eca5d9120c17d441a2f38596e8ed2b9
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
+  glog: 5337263514dd6f09803962437687240c5dc39aa4
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   RCT-Folly: a21c126816d8025b547704b777a2ba552f3d9fa9
@@ -523,10 +523,10 @@ SPEC CHECKSUMS:
   React-RCTVibration: e3ffca672dd3772536cb844274094b0e2c31b187
   React-runtimeexecutor: dec32ee6f2e2a26e13e58152271535fadff5455a
   ReactCommon: 57b69f6383eafcbd7da625bfa6003810332313c4
-  RNShare: 3185c074441b7e8897014d95ba982434a0a024a1
+  RNShare: ab582e93876d9df333a531390c658c31b50a767d
   Yoga: e7dc4e71caba6472ff48ad7d234389b91dadc280
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 7ff679d8fdb1057574cee8132657f19f2cce5036
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/ios/EmailShare.m
+++ b/ios/EmailShare.m
@@ -131,7 +131,7 @@
             // on the finish delegate.
             // For now, call it here for consistency with
             // GenericShare.shareSingle
-            successCallback(@[]);
+            successCallback(@[@true, @""]);
         });
     }
 }

--- a/ios/FacebookStories.m
+++ b/ios/FacebookStories.m
@@ -21,7 +21,9 @@ RCT_EXPORT_MODULE();
 
     NSURL *urlScheme = [NSURL URLWithString:@"facebook-stories://share"];
     if (![[UIApplication sharedApplication] canOpenURL:urlScheme]) {
-        [self fallbackFacebook];
+        NSError* error = [self fallbackFacebook];
+        failureCallback(error);
+        return;
     }
 
     // Create dictionary of assets and attribution
@@ -78,10 +80,10 @@ RCT_EXPORT_MODULE();
     [[UIPasteboard generalPasteboard] setItems:pasteboardItems options:pasteboardOptions];
     [[UIApplication sharedApplication] openURL:urlScheme options:@{} completionHandler:nil];
 
-    successCallback(@[]);
+    successCallback(@[@true, @""]);
 }
 
-- (void)fallbackFacebook {
+- (NSError*)fallbackFacebook {
     // Cannot open facebook
     NSString *stringURL = @"https://itunes.apple.com/app/facebook/id284882215";
     NSURL *url = [NSURL URLWithString:stringURL];
@@ -92,5 +94,6 @@ RCT_EXPORT_MODULE();
     NSError *error = [NSError errorWithDomain:@"com.rnshare" code:1 userInfo:userInfo];
 
     NSLog(errorMessage);
+    return error;
 }
 @end

--- a/ios/GenericShare.m
+++ b/ios/GenericShare.m
@@ -47,7 +47,7 @@
 
         UIViewController *ctrl = RCTPresentedViewController();
         [ctrl presentViewController:composeController animated:YES completion:Nil];
-        successCallback(@[]);
+        successCallback(@[@true, @""]);
       } else {
         NSString *errorMessage = @"Not installed";
         NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};

--- a/ios/GooglePlusShare.m
+++ b/ios/GooglePlusShare.m
@@ -22,10 +22,15 @@
 
         if ([[UIApplication sharedApplication] canOpenURL: gplusURL]) {
             [[UIApplication sharedApplication] openURL:gplusURL];
-            successCallback(@[]);
+            successCallback(@[@true, @""]);
         } else {
             // Cannot open gplus
-            NSLog(@"error web intent");
+            NSString *errorMessage = @"Not installed";
+            NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};
+            NSError *error = [NSError errorWithDomain:@"com.rnshare" code:1 userInfo:userInfo];
+
+            NSLog(errorMessage);
+            failureCallback(error);
         }
     }
 }

--- a/ios/InstagramShare.m
+++ b/ios/InstagramShare.m
@@ -36,7 +36,7 @@
     
     if ([[UIApplication sharedApplication] canOpenURL: shareURL]) {
         [[UIApplication sharedApplication] openURL: shareURL];
-        successCallback(@[]);
+        successCallback(@[@true, @""]);
     } else {
         // Cannot open instagram
         NSString *stringURL = @"https://itunes.apple.com/app/instagram/id389801252";
@@ -76,7 +76,7 @@
         }
     } else {
         [[UIApplication sharedApplication] openURL: [NSURL URLWithString:@"instagram://camera"]];
-        successCallback(@[]);
+        successCallback(@[@true, @""]);
     }
 }
 
@@ -104,7 +104,7 @@
                     [[UIApplication sharedApplication] openURL:instagramURL options:@{} completionHandler:NULL];
                 }
                 if (successCallback != NULL) {
-                    successCallback(@[]);
+                    successCallback(@[@true, @""]);
                 }
             }
         }

--- a/ios/InstagramStories.m
+++ b/ios/InstagramStories.m
@@ -20,7 +20,9 @@ RCT_EXPORT_MODULE();
 
     NSURL *urlScheme = [NSURL URLWithString:@"instagram-stories://share"];
     if (![[UIApplication sharedApplication] canOpenURL:urlScheme]) {
-        [self fallbackInstagram];
+        NSError* error = [self fallbackInstagram];
+        failureCallback(error);
+        return;
     }
 
     // Create dictionary of assets and attribution
@@ -75,10 +77,10 @@ RCT_EXPORT_MODULE();
     [[UIPasteboard generalPasteboard] setItems:pasteboardItems options:pasteboardOptions];
     [[UIApplication sharedApplication] openURL:urlScheme options:@{} completionHandler:nil];
 
-    successCallback(@[]);
+    successCallback(@[@true, @""]);
 }
 
-- (void)fallbackInstagram {
+- (NSError*)fallbackInstagram {
     // Cannot open instagram
     NSString *stringURL = @"https://itunes.apple.com/app/instagram/id389801252";
     NSURL *url = [NSURL URLWithString:stringURL];
@@ -89,6 +91,7 @@ RCT_EXPORT_MODULE();
     NSError *error = [NSError errorWithDomain:@"com.rnshare" code:1 userInfo:userInfo];
 
     NSLog(errorMessage);
+    return error;
 }
 // https://instagram.fhrk1-1.fna.fbcdn.net/vp/80c479ffc246a9320e614fa4def6a3dc/5C667D3F/t51.12442-15/e35/50679864_1663709050595244_6964601913751831460_n.jpg?_nc_ht=instagram.fhrk1-1.fna.fbcdn.net
 @end

--- a/ios/TelegramShare.m
+++ b/ios/TelegramShare.m
@@ -28,7 +28,7 @@
     
     if ([[UIApplication sharedApplication] canOpenURL: shareURL]) {
         [[UIApplication sharedApplication] openURL: shareURL];
-        successCallback(@[]);
+        successCallback(@[@true, @""]);
     } else {
         // Cannot open telegram
         NSString *stringURL = @"https://itunes.apple.com/app/telegram-messenger/id686449807";

--- a/ios/ViberShare.m
+++ b/ios/ViberShare.m
@@ -26,7 +26,7 @@
     
     if ([[UIApplication sharedApplication] canOpenURL: shareURL]) {
         [[UIApplication sharedApplication] openURL: shareURL];
-        successCallback(@[]);
+        successCallback(@[@true, @""]);
     } else {
         // Cannot open viber
         NSString *stringURL = @"https://apps.apple.com/app/viber-messenger-chats-calls/id382617920";

--- a/ios/WhatsAppShare.m
+++ b/ios/WhatsAppShare.m
@@ -46,7 +46,7 @@ RCT_EXPORT_MODULE();
             
             [documentInteractionController presentOpenInMenuFromRect:CGRectZero inView:[[[[[UIApplication sharedApplication] delegate] window] rootViewController] view] animated:YES];
             NSLog(@"Done whatsapp movie");
-            successCallback(@[]);
+            successCallback(@[@true, @""]);
         } else if ([options[@"url"] rangeOfString:@"png"].location != NSNotFound || [options[@"url"] rangeOfString:@"jpeg"].location != NSNotFound || [options[@"url"] rangeOfString:@"jpg"].location != NSNotFound || [options[@"url"] rangeOfString:@"gif"].location != NSNotFound) {
             UIImage * image;
             NSURL *imageURL = [RCTConvert NSURL:options[@"url"]];
@@ -71,7 +71,7 @@ RCT_EXPORT_MODULE();
                     documentInteractionController.delegate = self;
                     
                     [documentInteractionController presentOpenInMenuFromRect:CGRectZero inView:[[[[[UIApplication sharedApplication] delegate] window] rootViewController] view] animated:YES];
-                    successCallback(@[]);
+                    successCallback(@[@true, @""]);
                 }
             } else {
                 NSError *error = [NSError errorWithDomain:@"com.rnshare" code:3 userInfo:@{ NSLocalizedDescriptionKey:@"Something went wrong"}];
@@ -85,7 +85,7 @@ RCT_EXPORT_MODULE();
             
             if ([[UIApplication sharedApplication] canOpenURL: whatsappURL]) {
                 [[UIApplication sharedApplication] openURL: whatsappURL];
-                successCallback(@[]);
+                successCallback(@[@true, @""]);
             }
         }
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -102,7 +102,7 @@ const RNShare = {
               },
               (success, message) => {
                 return resolve({
-                  success,
+                  success: Boolean(success),
                   message,
                 });
               },


### PR DESCRIPTION
# Overview
I made a few changes to improve iOS code and the Example project.
- On iOS the usage of `successCallback` was sending parameters empty, so, on JS code the result of `status` and `message` get `undefined`, I added a `true` boolean and a empty message just to avoid `undefined`.
- When sharing Facebook Stories, Instagram Stories or Google Plus, you did't get a error if the user not have the application installed, it was just opening the App Store, now we have a `failureCallback` (the code was there but not used).
- I have added two more examples to Google Plus and WhatsApp, and the result of each share too. 
- I added a `Boolean` convertion on response from `shareSingle` because the status was getting `1` and not `true`
- I updated the version of `RNShare` on `Podfile`to the latest too. 
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->


# Test Plan
- To test this changes you can check every `shareSingle` and needs to get `status`: `true` and a empty `message`, not `undefined`.
- In the example app we have two more options (Google Plus and WhatsApp) to test the share single.
- For sharing Facebook Stories, Instagram Stories and Google Plus when you don't have the application the code need to reach a catch with the error.

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
