### PR TITLE
feat(android, ios): Implement SMS share

### DIFF
--- a/android/src/main/java/cl/json/social/SMSShare.java
+++ b/android/src/main/java/cl/json/social/SMSShare.java
@@ -28,7 +28,7 @@ public class SMSShare extends SingleShareIntent {
     @Override
     public void open(ReadableMap options) throws ActivityNotFoundException {
         super.open(options);
-        //  extra params here
+        // TODO: Open "sms://{address}/?body={message}";
         this.openIntentChooser();
     }
 

--- a/ios/MessengerShare.h
+++ b/ios/MessengerShare.h
@@ -1,0 +1,8 @@
+#import <UIKit/UIKit.h>
+
+#import <React/RCTBridgeModule.h>
+
+@interface MessengerShare : NSObject <RCTBridgeModule>
+
+- (void)shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback;
+@end

--- a/ios/MessengerShare.m
+++ b/ios/MessengerShare.m
@@ -1,0 +1,35 @@
+#import "MessengerShare.h"
+
+#import <React/RCTConvert.h>
+
+@implementation MessengerShare
+RCT_EXPORT_MODULE();
+
+- (void)shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback {
+
+  if ([options objectForKey:@"url"] && [options objectForKey:@"url"] != [NSNull null]) {
+
+    NSString *urlString = [NSString stringWithFormat:@"fb-messenger://share?link=%@", [RCTConvert NSString:options[@"url"]]];
+    NSURL *url = [NSURL URLWithString:urlString];
+
+    if ([[UIApplication sharedApplication] canOpenURL:url]) {
+      [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
+
+      successCallback(@[@true, @""]);
+    } else {
+      // Cannot open Messenger
+      NSString *contentLinkString = @"https://apps.apple.com/us/app/messenger/id454638411";
+      NSURL *url = [NSURL URLWithString:contentLinkString];
+      [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
+
+      NSString *errorMessage = @"Not installed";
+      NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};
+      NSError *error = [NSError errorWithDomain:@"com.rnshare" code:1 userInfo:userInfo];
+
+      NSLog(@"%@", errorMessage);
+      failureCallback(error);
+    }
+  }
+}
+
+@end

--- a/ios/RNShare.m
+++ b/ios/RNShare.m
@@ -19,6 +19,7 @@
 #import "EmailShare.h"
 #import "TelegramShare.h"
 #import "ViberShare.h"
+#import "MessengerShare.h"
 #import "RNShareActivityItemSource.h"
 #import "RNShareUtils.h"
 
@@ -84,6 +85,7 @@ RCT_EXPORT_MODULE()
     @"INSTAGRAMSTORIES": @"instagramstories",
     @"TELEGRAM": @"telegram",
     @"EMAIL": @"email",
+    @"MESSENGER": @"messanger",
     @"VIBER": @"viber",
 
     @"SHARE_BACKGROUND_IMAGE": @"shareBackgroundImage",
@@ -149,7 +151,11 @@ RCT_EXPORT_METHOD(shareSingle:(NSDictionary *)options
             NSLog(@"TRY OPEN viber");
             ViberShare *shareCtl = [[ViberShare alloc] init];
             [shareCtl shareSingle:options failureCallback: failureCallback successCallback: successCallback];
-        } 
+        } else if([social isEqualToString:@"messenger"]) {
+            NSLog(@"TRY OPEN messenger");
+            MessengerShare *shareCtl = [[MessengerShare alloc] init];
+            [shareCtl shareSingle:options failureCallback: failureCallback successCallback: successCallback];
+        }
     } else {
         RCTLogError(@"key 'social' missing in options");
         return;

--- a/ios/RNShare.m
+++ b/ios/RNShare.m
@@ -20,6 +20,7 @@
 #import "TelegramShare.h"
 #import "ViberShare.h"
 #import "MessengerShare.h"
+#import "SMSShare.h"
 #import "RNShareActivityItemSource.h"
 #import "RNShareUtils.h"
 
@@ -87,6 +88,7 @@ RCT_EXPORT_MODULE()
     @"EMAIL": @"email",
     @"MESSENGER": @"messanger",
     @"VIBER": @"viber",
+    @"MESSAGES": @"messages",
 
     @"SHARE_BACKGROUND_IMAGE": @"shareBackgroundImage",
     @"SHARE_BACKGROUND_VIDEO": @"shareBackgroundVideo",
@@ -154,6 +156,10 @@ RCT_EXPORT_METHOD(shareSingle:(NSDictionary *)options
         } else if([social isEqualToString:@"messenger"]) {
             NSLog(@"TRY OPEN messenger");
             MessengerShare *shareCtl = [[MessengerShare alloc] init];
+            [shareCtl shareSingle:options failureCallback: failureCallback successCallback: successCallback];
+        } else if([social isEqualToString:@"messages"]) {
+            NSLog(@"TRY OPEN messages");
+            SMSShare *shareCtl = [[SMSShare alloc] init];
             [shareCtl shareSingle:options failureCallback: failureCallback successCallback: successCallback];
         }
     } else {

--- a/ios/RNShare.xcodeproj/project.pbxproj
+++ b/ios/RNShare.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6513A53928AF109A00F0AE09 /* MessengerShare.m in Sources */ = {isa = PBXBuildFile; fileRef = 6513A53828AF109A00F0AE09 /* MessengerShare.m */; };
 		65B4E1BA28AF0DC800D905B8 /* RNShareUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B4E1B928AF0DC800D905B8 /* RNShareUtils.m */; };
 		6D697F8423A86EBC00F754A1 /* RNShareActivityItemSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D697F8323A86EBC00F754A1 /* RNShareActivityItemSource.m */; };
 		B33C22851D441713006BCD98 /* GenericShare.m in Sources */ = {isa = PBXBuildFile; fileRef = B33C22841D441713006BCD98 /* GenericShare.m */; };
@@ -33,6 +34,8 @@
 
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libRNShare.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNShare.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		6513A53728AF108500F0AE09 /* MessengerShare.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MessengerShare.h; sourceTree = "<group>"; };
+		6513A53828AF109A00F0AE09 /* MessengerShare.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MessengerShare.m; sourceTree = "<group>"; };
 		65B4E1B828AF0DB400D905B8 /* RNShareUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNShareUtils.h; sourceTree = "<group>"; };
 		65B4E1B928AF0DC800D905B8 /* RNShareUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNShareUtils.m; sourceTree = "<group>"; };
 		6D697F8223A86EBC00F754A1 /* RNShareActivityItemSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNShareActivityItemSource.h; sourceTree = "<group>"; };
@@ -101,6 +104,8 @@
 				CE0C76361E9E7DE100ED396E /* InstagramShare.m */,
 				FCC7BB4D2214566C00E1EA39 /* InstagramStories.h */,
 				FCC7BB4E221457EF00E1EA39 /* InstagramStories.m */,
+				6513A53728AF108500F0AE09 /* MessengerShare.h */,
+				6513A53828AF109A00F0AE09 /* MessengerShare.m */,
 				65B4E1B828AF0DB400D905B8 /* RNShareUtils.h */,
 				65B4E1B928AF0DC800D905B8 /* RNShareUtils.m */,
 				B33C22871D4419DA006BCD98 /* WhatsAppShare.h */,
@@ -175,6 +180,7 @@
 				B33C22891D4419E8006BCD98 /* WhatsAppShare.m in Sources */,
 				B33C228B1D442577006BCD98 /* EmailShare.m in Sources */,
 				FCC7BB4F221457EF00E1EA39 /* InstagramStories.m in Sources */,
+				6513A53928AF109A00F0AE09 /* MessengerShare.m in Sources */,
 				B33C22851D441713006BCD98 /* GenericShare.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/RNShare.xcodeproj/project.pbxproj
+++ b/ios/RNShare.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		6513A53928AF109A00F0AE09 /* MessengerShare.m in Sources */ = {isa = PBXBuildFile; fileRef = 6513A53828AF109A00F0AE09 /* MessengerShare.m */; };
+		6513A53C28AF4D3300F0AE09 /* SMSShare.m in Sources */ = {isa = PBXBuildFile; fileRef = 6513A53B28AF4D3300F0AE09 /* SMSShare.m */; };
 		65B4E1BA28AF0DC800D905B8 /* RNShareUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B4E1B928AF0DC800D905B8 /* RNShareUtils.m */; };
 		6D697F8423A86EBC00F754A1 /* RNShareActivityItemSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D697F8323A86EBC00F754A1 /* RNShareActivityItemSource.m */; };
 		B33C22851D441713006BCD98 /* GenericShare.m in Sources */ = {isa = PBXBuildFile; fileRef = B33C22841D441713006BCD98 /* GenericShare.m */; };
@@ -36,6 +37,8 @@
 		134814201AA4EA6300B7C361 /* libRNShare.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNShare.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		6513A53728AF108500F0AE09 /* MessengerShare.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MessengerShare.h; sourceTree = "<group>"; };
 		6513A53828AF109A00F0AE09 /* MessengerShare.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MessengerShare.m; sourceTree = "<group>"; };
+		6513A53A28AF4D1E00F0AE09 /* SMSShare.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SMSShare.h; sourceTree = "<group>"; };
+		6513A53B28AF4D3300F0AE09 /* SMSShare.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SMSShare.m; sourceTree = "<group>"; };
 		65B4E1B828AF0DB400D905B8 /* RNShareUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNShareUtils.h; sourceTree = "<group>"; };
 		65B4E1B928AF0DC800D905B8 /* RNShareUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNShareUtils.m; sourceTree = "<group>"; };
 		6D697F8223A86EBC00F754A1 /* RNShareActivityItemSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNShareActivityItemSource.h; sourceTree = "<group>"; };
@@ -108,6 +111,8 @@
 				6513A53828AF109A00F0AE09 /* MessengerShare.m */,
 				65B4E1B828AF0DB400D905B8 /* RNShareUtils.h */,
 				65B4E1B928AF0DC800D905B8 /* RNShareUtils.m */,
+				6513A53A28AF4D1E00F0AE09 /* SMSShare.h */,
+				6513A53B28AF4D3300F0AE09 /* SMSShare.m */,
 				B33C22871D4419DA006BCD98 /* WhatsAppShare.h */,
 				B33C22881D4419E8006BCD98 /* WhatsAppShare.m */,
 			);
@@ -182,6 +187,7 @@
 				FCC7BB4F221457EF00E1EA39 /* InstagramStories.m in Sources */,
 				6513A53928AF109A00F0AE09 /* MessengerShare.m in Sources */,
 				B33C22851D441713006BCD98 /* GenericShare.m in Sources */,
+				6513A53C28AF4D3300F0AE09 /* SMSShare.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/RNShare.xcodeproj/project.pbxproj
+++ b/ios/RNShare.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		4EED9CAF24F5A2EB006505C4 /* Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 4EED9CAE24F5A2EB006505C4 /* Utils.m */; };
+		65B4E1BA28AF0DC800D905B8 /* RNShareUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B4E1B928AF0DC800D905B8 /* RNShareUtils.m */; };
 		6D697F8423A86EBC00F754A1 /* RNShareActivityItemSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D697F8323A86EBC00F754A1 /* RNShareActivityItemSource.m */; };
 		B33C22851D441713006BCD98 /* GenericShare.m in Sources */ = {isa = PBXBuildFile; fileRef = B33C22841D441713006BCD98 /* GenericShare.m */; };
 		B33C22891D4419E8006BCD98 /* WhatsAppShare.m in Sources */ = {isa = PBXBuildFile; fileRef = B33C22881D4419E8006BCD98 /* WhatsAppShare.m */; };
@@ -33,8 +33,8 @@
 
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libRNShare.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNShare.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		4EED9CAD24F5A2EB006505C4 /* Utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Utils.h; sourceTree = "<group>"; };
-		4EED9CAE24F5A2EB006505C4 /* Utils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Utils.m; sourceTree = "<group>"; };
+		65B4E1B828AF0DB400D905B8 /* RNShareUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNShareUtils.h; sourceTree = "<group>"; };
+		65B4E1B928AF0DC800D905B8 /* RNShareUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNShareUtils.m; sourceTree = "<group>"; };
 		6D697F8223A86EBC00F754A1 /* RNShareActivityItemSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNShareActivityItemSource.h; sourceTree = "<group>"; };
 		6D697F8323A86EBC00F754A1 /* RNShareActivityItemSource.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNShareActivityItemSource.m; sourceTree = "<group>"; };
 		B33C22841D441713006BCD98 /* GenericShare.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GenericShare.m; sourceTree = "<group>"; };
@@ -89,22 +89,22 @@
 		B33C22801D43F9B0006BCD98 /* social */ = {
 			isa = PBXGroup;
 			children = (
-				CE0C76361E9E7DE100ED396E /* InstagramShare.m */,
-				CE0C76621E9E869300ED396E /* InstagramShare.h */,
-				B33C22841D441713006BCD98 /* GenericShare.m */,
-				B33C22861D441723006BCD98 /* GenericShare.h */,
-				B33C22871D4419DA006BCD98 /* WhatsAppShare.h */,
-				B33C22881D4419E8006BCD98 /* WhatsAppShare.m */,
-				B33C228A1D442576006BCD98 /* EmailShare.m */,
 				B33C228C1D442583006BCD98 /* EmailShare.h */,
-				4EED9CAD24F5A2EB006505C4 /* Utils.h */,
-				4EED9CAE24F5A2EB006505C4 /* Utils.m */,
-				B3EEE48D1D4844E7008422B6 /* GooglePlusShare.m */,
-				B3EEE48F1D4844F4008422B6 /* GooglePlusShare.h */,
-				FCC7BB4D2214566C00E1EA39 /* InstagramStories.h */,
-				FCC7BB4E221457EF00E1EA39 /* InstagramStories.m */,
+				B33C228A1D442576006BCD98 /* EmailShare.m */,
 				F1A1AD562444B09B00E32E33 /* FacebookStories.h */,
 				F1A1AD572444B09B00E32E33 /* FacebookStories.m */,
+				B33C22861D441723006BCD98 /* GenericShare.h */,
+				B33C22841D441713006BCD98 /* GenericShare.m */,
+				B3EEE48F1D4844F4008422B6 /* GooglePlusShare.h */,
+				B3EEE48D1D4844E7008422B6 /* GooglePlusShare.m */,
+				CE0C76621E9E869300ED396E /* InstagramShare.h */,
+				CE0C76361E9E7DE100ED396E /* InstagramShare.m */,
+				FCC7BB4D2214566C00E1EA39 /* InstagramStories.h */,
+				FCC7BB4E221457EF00E1EA39 /* InstagramStories.m */,
+				65B4E1B828AF0DB400D905B8 /* RNShareUtils.h */,
+				65B4E1B928AF0DC800D905B8 /* RNShareUtils.m */,
+				B33C22871D4419DA006BCD98 /* WhatsAppShare.h */,
+				B33C22881D4419E8006BCD98 /* WhatsAppShare.m */,
 			);
 			name = social;
 			sourceTree = "<group>";
@@ -167,9 +167,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				F1A1AD582444B09B00E32E33 /* FacebookStories.m in Sources */,
+				65B4E1BA28AF0DC800D905B8 /* RNShareUtils.m in Sources */,
 				6D697F8423A86EBC00F754A1 /* RNShareActivityItemSource.m in Sources */,
 				CE0C76371E9E7DE100ED396E /* InstagramShare.m in Sources */,
-				4EED9CAF24F5A2EB006505C4 /* Utils.m in Sources */,
 				B3EEE48E1D4844E7008422B6 /* GooglePlusShare.m in Sources */,
 				B3E7B58A1CC2AC0600A0062D /* RNShare.m in Sources */,
 				B33C22891D4419E8006BCD98 /* WhatsAppShare.m in Sources */,

--- a/ios/RNShareUtils.h
+++ b/ios/RNShareUtils.h
@@ -1,3 +1,5 @@
+#import <Foundation/Foundation.h>
+
 @interface RNShareUtils : NSObject
 +(NSString*)getExtensionFromBase64:(NSString*)base64String;
 +(NSURL*)getPathFromBase64:(NSString*)base64String with:(NSData*)data;

--- a/ios/SMSShare.h
+++ b/ios/SMSShare.h
@@ -1,0 +1,9 @@
+#import <UIKit/UIKit.h>
+
+#import <React/RCTBridgeModule.h>
+
+@interface SMSShare : NSObject <RCTBridgeModule>
+
+- (void)shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback;
+
+@end

--- a/ios/SMSShare.m
+++ b/ios/SMSShare.m
@@ -1,0 +1,28 @@
+#import "SMSShare.h"
+
+#import <React/RCTConvert.h>
+
+@implementation SMSShare
+RCT_EXPORT_MODULE();
+
+- (void)shareSingle:(NSDictionary *)options failureCallback:(RCTResponseErrorBlock)failureCallback successCallback:(RCTResponseSenderBlock)successCallback {
+
+  NSString *urlString = [NSString stringWithFormat:@"sms://%@/&body=%@", [RCTConvert NSString:options[@"recipient"]], [RCTConvert NSString:options[@"message"]]];
+  NSURL *url = [NSURL URLWithString:urlString];
+
+  if ([[UIApplication sharedApplication] canOpenURL:url]) {
+    [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
+
+    successCallback(@[@true, @""]);
+  } else {
+    // Cannot open Messages
+    NSString *errorMessage = @"Not installed";
+    NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};
+    NSError *error = [NSError errorWithDomain:@"com.rnshare" code:1 userInfo:userInfo];
+
+    NSLog(@"%@", errorMessage);
+    failureCallback(error);
+  }
+}
+
+@end

--- a/ios/WhatsAppShare.m
+++ b/ios/WhatsAppShare.m
@@ -1,5 +1,5 @@
 //
-//  FacebookShare.m
+//  WhatsAppShare.m
 //  RNShare
 //
 //  Created by Diseño Uno BBCL on 23-07-16.

--- a/website/docs/share-single.mdx
+++ b/website/docs/share-single.mdx
@@ -80,7 +80,7 @@ You can pass the option that will be handled by the native code, similar to `Sha
 | **PINTEREST**         |   ✅    | 🚫  | 🚫      |
 | **SMS**               |   ✅    | 🚫  | 🚫      |
 | **SNAPCHAT**          |   ✅    | 🚫  | 🚫      |
-| **MESSENGER**         |   ✅    | 🚫  | 🚫      |
+| **MESSENGER**         |   ✅    | ✅  | 🚫      |
 | **LINKEDIN**          |   ✅    | 🚫  | 🚫      |
 | **TELEGRAM**          |   ✅    | ✅  | 🚫      |
 | **VIBER**             |   ✅    | ✅  | 🚫      |

--- a/website/docs/share-single.mdx
+++ b/website/docs/share-single.mdx
@@ -78,7 +78,7 @@ You can pass the option that will be handled by the native code, similar to `Sha
 | **GOOGLEPLUS**        |   ✅    | ✅  | 🚫      |
 | **EMAIL**             |   ✅    | ✅  | 🚫      |
 | **PINTEREST**         |   ✅    | 🚫  | 🚫      |
-| **SMS**               |   ✅    | 🚫  | 🚫      |
+| **SMS**               |   ✅    | ✅  | 🚫      |
 | **SNAPCHAT**          |   ✅    | 🚫  | 🚫      |
 | **MESSENGER**         |   ✅    | ✅  | 🚫      |
 | **LINKEDIN**          |   ✅    | 🚫  | 🚫      |


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

SMS sharing is marked as supported but it doesn't work on my end.

- [ ] iOS
- [ ] Android
- [ ] Example

I want to port this implementation into this repo.

```js

Linking.openURL('sms://[phone_number]/?body=[body]'); // Android

Linking.openURL('sms://[phone_number]/&body=[body]'); // iOS
```

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
