### PR TITLE
WhatsApp share issue #1249

### DIFF
--- a/android/src/main/java/cl/json/social/WhatsAppBusinessShare.java
+++ b/android/src/main/java/cl/json/social/WhatsAppBusinessShare.java
@@ -1,7 +1,7 @@
 package cl.json.social;
 
 import android.content.ActivityNotFoundException;
-import android.content.ComponentName;
+// import android.content.ComponentName;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableMap;
@@ -14,10 +14,10 @@ public class WhatsAppBusinessShare extends SingleShareIntent {
     private static final String PACKAGE = "com.whatsapp.w4b";
     private static final String PLAY_STORE_LINK = "market://details?id=com.whatsapp.w4b";
     
-    private static final String START_CONVERSATION_CLASS = "com.whatsapp.Conversation";
+    // private static final String START_CONVERSATION_CLASS = "com.whatsapp.Conversation";
 
     // must be small enough so that both activities are triggered while the app is still on foreground
-    private static final int START_ACTIVITY_TIME_GAP_MS = 10; 
+    // private static final int START_ACTIVITY_TIME_GAP_MS = 10; 
 
     public WhatsAppBusinessShare(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -26,19 +26,22 @@ public class WhatsAppBusinessShare extends SingleShareIntent {
     public void open(ReadableMap options) throws ActivityNotFoundException {
         super.open(options);
         
-        if (options.hasKey("whatsAppNumber")) {
-            try {                
+        // Fixing it doesn't work if user have more than one whatsapp installed in the device. #1249
+        // To fix that issue #1249 commenting below code
+        
+        // if (options.hasKey("whatsAppNumber")) {
+        //    try {                
                 // create an empty conversation in case it's not on contacts
-                this.getIntent().setComponent(new ComponentName(PACKAGE, START_CONVERSATION_CLASS)); 
-                this.openIntentChooser();
+        //        this.getIntent().setComponent(new ComponentName(PACKAGE, START_CONVERSATION_CLASS)); 
+        //        this.openIntentChooser();
 
                 // leave room for the conversation to be created
-                Thread.sleep(START_ACTIVITY_TIME_GAP_MS);   
+        //        Thread.sleep(START_ACTIVITY_TIME_GAP_MS);   
 
-            } catch (Exception ex) {
-                ex.printStackTrace();
-            }
-        }
+        //    } catch (Exception ex) {
+        //        ex.printStackTrace();
+        //    }
+        // }
 
         // restore default behavior to share to conversation
         this.getIntent().setComponent(null); 

--- a/android/src/main/java/cl/json/social/WhatsAppShare.java
+++ b/android/src/main/java/cl/json/social/WhatsAppShare.java
@@ -1,7 +1,7 @@
 package cl.json.social;
 
 import android.content.ActivityNotFoundException;
-import android.content.ComponentName;
+// import android.content.ComponentName;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableMap;
@@ -17,7 +17,7 @@ public class WhatsAppShare extends SingleShareIntent {
     private static final String START_CONVERSATION_CLASS = "com.whatsapp.Conversation";
     
     // must be small enough so that both activities are triggered while the app is still on foreground
-    private static final int START_ACTIVITY_TIME_GAP_MS = 10; 
+    // private static final int START_ACTIVITY_TIME_GAP_MS = 10; 
 
     public WhatsAppShare(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -25,20 +25,21 @@ public class WhatsAppShare extends SingleShareIntent {
     @Override
     public void open(ReadableMap options) throws ActivityNotFoundException {
         super.open(options);
-        
-        if (options.hasKey("whatsAppNumber")) {
-            try {                
+        // Fixging it doesn't work if user have more than one whatsapp installed in the device. #1249
+        // To fix that issue #1249 commenting below code
+        // if (options.hasKey("whatsAppNumber")) {
+        //    try {                
                 // create an empty conversation in case it's not on contacts
-                this.getIntent().setComponent(new ComponentName(PACKAGE, START_CONVERSATION_CLASS)); 
-                this.openIntentChooser();
+        //        this.getIntent().setComponent(new ComponentName(PACKAGE, START_CONVERSATION_CLASS)); 
+        //        this.openIntentChooser();
 
                 // leave room for the conversation to be created
-                Thread.sleep(START_ACTIVITY_TIME_GAP_MS);   
+        //        Thread.sleep(START_ACTIVITY_TIME_GAP_MS);   
 
-            } catch (Exception ex) {
-                ex.printStackTrace();
-            }
-        }
+        //    } catch (Exception ex) {
+        //        ex.printStackTrace();
+        //    }
+        // }
 
         // restore default behavior to share to conversation
         this.getIntent().setComponent(null); 


### PR DESCRIPTION
# Overview
shareSingle method doesn't work if the user has more than one WhatsApp(Cloned Whatsapp) installed on the device. Similar #1249

# Steps
1) Install WhatsApp in Android and Create a clone of the same, now you will have two whatsapp
2) Now Share.shareSingle(shareOptions);  with PDF file share
3) A window option will open and asking which whatsapp would you like to choose
4) Choose any Whatsapp and nothing will be inside conversation on Whatsapp

To fix above issue, this PR will solve that issue
