### PR TITLE
Fixed Twitter shareSingle with image on iOS

### DIFF
--- a/ios/GenericShare.m
+++ b/ios/GenericShare.m
@@ -17,7 +17,7 @@
     inAppBaseUrl:(NSString *)inAppBaseUrl {
 
     NSLog(@"Try open view");
-    if(![serviceType isEqualToString:@"com.apple.social.twitter"] && [[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:inAppBaseUrl]]) {
+    if([serviceType isEqualToString:@"com.apple.social.twitter"]) {
         SLComposeViewController *composeController = [SLComposeViewController  composeViewControllerForServiceType:serviceType];
 
         NSURL *URL = [RCTConvert NSURL:options[@"url"]];


### PR DESCRIPTION
# Overview
With this PR, Twitter shareSingle with image works on iOS.
Without this, shareSingle will copy the image url as a string in the Twitter card message.