### PR TITLE
Fix: #1285

### DIFF
--- a/ios/GenericShare.m
+++ b/ios/GenericShare.m
@@ -17,7 +17,7 @@
     inAppBaseUrl:(NSString *)inAppBaseUrl {
 
     NSLog(@"Try open view");
-    if(![serviceType isEqualToString:@"com.apple.social.twitter"] && [[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:inAppBaseUrl]]) {
+    if([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:inAppBaseUrl]]) {
         SLComposeViewController *composeController = [SLComposeViewController  composeViewControllerForServiceType:serviceType];
 
         NSURL *URL = [RCTConvert NSURL:options[@"url"]];


### PR DESCRIPTION
Remove condition what check isTwitter from GenericShare.m

# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

when delete ```![serviceType isEqualToString:@"com.apple.social.twitter"] && ```, it's seem to like work. facebook, and twitter both.

![IMG_0121](https://user-images.githubusercontent.com/52395231/206352206-09cd44c0-d7cc-459a-b7a8-b93bab4304e5.PNG)

![IMG_0122](https://user-images.githubusercontent.com/52395231/206352219-188617cc-36cd-45f0-ac4f-2ca5965beec2.PNG)


ps. it's my first PR at public repo. So forgive me if I make a mistake.