### PR TITLE
Allow custom activity types to be specified inside activityItemSources

### DIFF
--- a/ios/RNShareActivityItemSource.m
+++ b/ios/RNShareActivityItemSource.m
@@ -197,7 +197,7 @@
         }
     }
     
-    return nil;
+    return activityType;
 }
 
 + (nullable id)objectForActivityType:(UIActivityType)activityType inDictionary:(nonnull NSDictionary *)dictionary {

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,10 +42,10 @@ export interface ActivityItem {
 
 export interface ActivityItemSource {
   placeholderItem: ActivityItem;
-  item: { [key in ActivityType]?: ActivityItem | null | undefined };
-  subject?: { [key in ActivityType]?: string };
-  dataTypeIdentifier?: { [key in ActivityType]?: string };
-  thumbnailImage?: { [key in ActivityType]?: string };
+  item: { [key in ActivityTypeItemSource]?: ActivityItem | null | undefined };
+  subject?: { [key in ActivityTypeItemSource]?: string };
+  dataTypeIdentifier?: { [key in ActivityTypeItemSource]?: string };
+  thumbnailImage?: { [key in ActivityTypeItemSource]?: string };
   linkMetadata?: LinkMetadata;
 }
 
@@ -124,6 +124,8 @@ export type ActivityType =
   | 'print'
   | 'saveToCameraRoll'
   | 'markupAsPDF'; // iOS 11 or late
+
+export type ActivityTypeItemSource = ActivityType | string;
 
 export interface ShareSingleResult {
   message: string;


### PR DESCRIPTION
# Overview

A few applications' api do not allow for sending of both messages and url (E.g.: #280 #760 WhatsApp, Slack). When this happens, the app api randomly chooses either the message or the url to be shared to the application (for WhatsApp, the message is always prioritized over the url). We would like to specify which of the two to send for these type of application when calling Share.open using activityItemSources.

# Test Plan

Inside where I am calling Share.open, I can now specify the bundle to specifically tell share options what to send and what not to, instead of just using the default ActivityTypes.
```ts
const url = payload.url ?? '';
const message = payload.message ?? '';
const options: ShareOptions = Platform.select({
	ios: {
		activityItemSources: [
			{
				placeholderItem: { type: 'url', content: url },
				item: { default: { type: 'url', content: url } },
			},
			{
				placeholderItem: { type: 'text', content: message },
				item: {
					default: { type: 'text', content: message },
					'net.whatsapp.WhatsApp.ShareExtension': null,
				},
			},
		],
	},
	default: {
		...payload,
	},
});
```

To verify the change works, try sharing using WhatsApp, now only the url is sent, the message is not. For other app shares, both the url and the message is still sent.