### PR TITLE
fix(android): instagram direct share plain text

### DIFF
--- a/android/src/main/java/cl/json/social/InstagramShare.java
+++ b/android/src/main/java/cl/json/social/InstagramShare.java
@@ -27,6 +27,17 @@ public class InstagramShare extends SingleShareIntent {
     public void open(ReadableMap options) throws ActivityNotFoundException {
             super.open(options);
 
+            if (!ShareIntent.hasValidKey("type", options)) {
+                Log.e("RNShare", "No type provided");
+                return;
+            }
+            String type = options.getString("type");
+
+            if (type.startsWith("text")) {
+               this.openInstagramIntentChooserForText(chooserTitle);
+                return;
+            }
+
             if (!ShareIntent.hasValidKey("url", options)) {
                 Log.e("RNShare", "No url provided");
                 return;
@@ -39,16 +50,10 @@ public class InstagramShare extends SingleShareIntent {
                 return;
             }
 
-
-            if (!ShareIntent.hasValidKey("type", options)) {
-                Log.e("RNShare", "No type provided");
-                return;
-            }
-            String type = options.getString("type");
             String extension = this.getExtension(type);
             Boolean isImage = type.startsWith("image");
 
-            this.openInstagramIntentChooser(url, chooserTitle, isImage, extension);
+            this.openInstagramIntentChooserForMedia(url, chooserTitle, isImage, extension);
     }
 
     protected void openInstagramUrlScheme(String url) {
@@ -63,7 +68,14 @@ public class InstagramShare extends SingleShareIntent {
             return ext[ext.length -1];
     }
 
-    protected void openInstagramIntentChooser(String url, String chooserTitle, Boolean isImage, String extension) {
+    protected void openInstagramIntentChooserForText(String chooserTitle) {
+            this.getIntent().setPackage(PACKAGE);
+            this.getIntent().setType("text/plain");
+            this.getIntent().setAction(Intent.ACTION_SEND);
+            super.openIntentChooser();
+    }
+
+    protected void openInstagramIntentChooserForMedia(String url, String chooserTitle, Boolean isImage, String extension) {
         Boolean shouldUseInternalStorage = ShareIntent.hasValidKey("useInternalStorage", options) && options.getBoolean("useInternalStorage");
         ShareFile shareFile = isImage 
             ? new ShareFile(url, "image/" + extension, "image", shouldUseInternalStorage, this.reactContext) 

--- a/example/App.js
+++ b/example/App.js
@@ -200,8 +200,11 @@ const App = () => {
 
   const shareToInstagramDirect = async () => {
     const shareOptions = {
-      message: encodeURI('Checkout the great search engine: https://google.com'),
+      message: encodeURI(
+        'Checkout the great search engine: https://google.com',
+      ),
       social: Share.Social.INSTAGRAM,
+      type: 'text/plain',
     };
 
     try {
@@ -219,7 +222,6 @@ const App = () => {
       backgroundImage: images.image1,
       social: Share.Social.INSTAGRAM_STORIES,
       appId: '219376304', //instagram appId
-
     };
 
     try {


### PR DESCRIPTION
# Overview
Hi there,
We are using your library at our company, however we had problems sharing direct messages on instagram with android.
The current behaviour is that nothing happens if a url is not provided, and when provided it says that the file type is not supported. 
This patch tries to fix that by passing `text/*` as type in the options.


# Test Plan
In the example app simply try to send an instagram direct message.

Cheers