### PR TITLE
feat(android): 🌟 add support for React Native 0.73

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,14 +1,11 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="cl.json">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
-        <provider
-            android:name=".RNShareFileProvider"
+        <provider android:name=".RNShareFileProvider"
             android:authorities="${applicationId}.rnshare.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
-            <meta-data
-                android:name="android.support.FILE_PROVIDER_PATHS"
+            <meta-data android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/share_download_paths" />
         </provider>
     </application>


### PR DESCRIPTION
# Overview
Starting from React Native v0.73 , all libraries will need to be updated with namespace due to the upgrade to AGP 8
https://github.com/react-native-community/discussions-and-proposals/issues/671

OS | Implemented
-- | --
iOS | ❌
Android | ✅

# Test Plan

I tested the changes on RN 0.71.11 and everything works!
