### PR TITLE
fix: add documentation for the newly required appId for ig stories

### DIFF
--- a/website/docs/share-single.mdx
+++ b/website/docs/share-single.mdx
@@ -110,7 +110,8 @@ const shareOptions = {
     backgroundBottomColor: '#fefefe',
     backgroundTopColor: '#906df4',
     attributionURL: 'http://deep-link-to-app', //in beta
-    social: Share.Social.INSTAGRAM_STORIES
+    social: Share.Social.INSTAGRAM_STORIES,
+    appId: 'your_fb_app_id' // required since  Jan 2023 (see: https://developers.facebook.com/docs/instagram/sharing-to-stories/#sharing-to-stories)
 };
 
 Share.shareSingle(shareOptions);
@@ -119,6 +120,7 @@ Share.shareSingle(shareOptions);
 
 | Name  | Type     | Description | Optional |
 | :---- | :------: | :--- | :--- |
+| appId | string   | (required) facebook app ID  | ❗️required
 | backgroundImage | string   | URL you want to share | ✅
 | stickerImage | string   | URL you want to share | ✅
 | backgroundBottomColor | string   | default #837DF4 | ✅


### PR DESCRIPTION
# Overview
since jan 2023, facebook requires appId for sharing to stories. adding that to the documentation so people know they need to add it


# Test Plan
no need , just updated docs. the code for appId already existed
