### PR TITLE
fix(ios): folly_compiler_flags missing on RN<=0.70

### DIFF
--- a/RNShare.podspec
+++ b/RNShare.podspec
@@ -2,6 +2,8 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
+folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
+
 Pod::Spec.new do |s|
   s.name         = "RNShare"
   s.version      = package["version"]


### PR DESCRIPTION
This PR fixes `RCT_NEW_ARCH_ENABLED=1 pod install` command on RN <= 0.70.