### PR TITLE
fix(android): Build fail in New Architecture

### DIFF
--- a/android/src/newarch/cl/json/RNShare.java
+++ b/android/src/newarch/cl/json/RNShare.java
@@ -29,7 +29,7 @@ public class RNShare extends NativeRNShareSpec {
     }
     
     @Override
-    public Map<String, Object> getConstants() {
+    public Map<String, Object> getTypedExportedConstants() {
         return delegate.getConstants();
     }
     


### PR DESCRIPTION
# Overview
This PR fixes a compile error on Android with the new architecture. The bug is explained in the following thread I opened: [https://github.com/react-native-share/react-native-share/issues/1415#issue-1790174827](url)