### PR TITLE
feat: adds linked in

### DIFF
--- a/ios/LinkedinShare.h
+++ b/ios/LinkedinShare.h
@@ -1,0 +1,25 @@
+//
+//  LinkedinShare.h
+//  RNShare
+//
+//  Created by Ralf Nieuwenhuizen on 12-04-17.
+//
+
+#import <UIKit/UIKit.h>
+// import RCTConvert
+#import <React/RCTConvert.h>
+// import RCTBridge
+#import <React/RCTBridge.h>
+// import RCTUIManager
+#import <React/RCTUIManager.h>
+// import RCTLog
+#import <React/RCTLog.h>
+// import RCTUtils
+#import <React/RCTUtils.h>
+@interface LinkedinShare : NSObject <RCTBridgeModule>
+
+- (void) shareSingle:(NSDictionary *)options reject:(RCTPromiseRejectBlock)reject resolve:(RCTPromiseResolveBlock)resolve;
+- (void)shareSingleImage:(NSDictionary *)options
+         reject:(RCTPromiseRejectBlock)reject
+         resolve:(RCTPromiseResolveBlock)resolve;
+@end

--- a/ios/LinkedinShare.h
+++ b/ios/LinkedinShare.h
@@ -19,7 +19,5 @@
 @interface LinkedinShare : NSObject <RCTBridgeModule>
 
 - (void) shareSingle:(NSDictionary *)options reject:(RCTPromiseRejectBlock)reject resolve:(RCTPromiseResolveBlock)resolve;
-- (void)shareSingleImage:(NSDictionary *)options
-         reject:(RCTPromiseRejectBlock)reject
-         resolve:(RCTPromiseResolveBlock)resolve;
+
 @end

--- a/ios/LinkedinShare.m
+++ b/ios/LinkedinShare.m
@@ -17,7 +17,7 @@
     
     NSLog(@"Try open view");
     
-    NSString *url = [NSString stringWithFormat:@"https://www.linkedin.com/shareArticle/?url=%@", options[@"url"]];
+    NSString *url = [NSString stringWithFormat:@"https://www.linkedin.com/sharing/share-offsite/?url=%@", options[@"url"]];
     NSURL *shareURL = [NSURL URLWithString:[url stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
 
   if ([[UIApplication sharedApplication] canOpenURL: shareURL]) {
@@ -37,78 +37,6 @@
         NSLog(@"%@", errorMessage);
         reject(@"com.rnshare",@"Not installed",error);
     }
-}
-
-- (void)shareSingleImage:(NSDictionary *)options
-         reject:(RCTPromiseRejectBlock)reject
-         resolve:(RCTPromiseResolveBlock)resolve {
-    
-    UIImage *image;
-    NSURL *imageURL = [RCTConvert NSURL:options[@"url"]];
-    if (imageURL) {
-        if (imageURL.fileURL || [imageURL.scheme.lowercaseString isEqualToString:@"data"]) {
-            NSError *error;
-            NSData *data = [NSData dataWithContentsOfURL:imageURL
-                                                 options:(NSDataReadingOptions)0
-                                                   error:&error];
-            if (!data) {
-                reject(@"com.rnshare",@"no data",error);
-                return;
-            }
-            image = [UIImage imageWithData: data];
-            [self savePictureAndOpenLinkedin: image
-                              reject: reject
-                              resolve: resolve];
-        }
-    } else {
-        [[UIApplication sharedApplication] openURL: [NSURL URLWithString:@"linkedin://camera"]];
-        resolve(@[@true, @""]);
-    }
-}
-
--(void)savePictureAndOpenLinkedin:(UIImage *)base64Image
-                   reject:(RCTPromiseRejectBlock)reject
-                   resolve:(RCTPromiseResolveBlock)resolve {
-    
-    NSURL *URL = [self fileURLWithTemporaryImageData:UIImageJPEGRepresentation(base64Image, 0.9)];
-    __block PHAssetChangeRequest *_mChangeRequest = nil;
-    __block PHObjectPlaceholder *placeholder;
-    
-    [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
-        
-        NSData *pngData = [NSData dataWithContentsOfURL:URL];
-        UIImage *image = [UIImage imageWithData:pngData];
-        _mChangeRequest = [PHAssetChangeRequest creationRequestForAssetFromImage:image];
-        placeholder = _mChangeRequest.placeholderForCreatedAsset;
-    } completionHandler:^(BOOL success, NSError *error) {
-        
-        if (success) {
-            NSURL *LinkedinURL = [NSURL URLWithString:[NSString stringWithFormat:@"linkedin://library?LocalIdentifier=\%@", [placeholder localIdentifier]]];
-            
-            if ([[UIApplication sharedApplication] canOpenURL:LinkedinURL]) {
-                if (@available(iOS 10.0, *)) {
-                    [[UIApplication sharedApplication] openURL:LinkedinURL options:@{} completionHandler:NULL];
-                }
-                if (resolve != NULL) {
-                    resolve(@[@true, @""]);
-                }
-            }
-        }
-        else {
-            //Error while writing
-            if (reject != NULL) {
-                reject(@"com.rnshare",@"error",error);
-            }
-        }
-    }];
-}
-
-- (NSURL *)fileURLWithTemporaryImageData:(NSData *)data {
-    NSString *writePath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"linkedin"];
-    if (![data writeToFile:writePath atomically:YES]) {
-        return nil;
-    }
-    return [NSURL fileURLWithPath:writePath];
 }
 
 @end

--- a/ios/LinkedinShare.m
+++ b/ios/LinkedinShare.m
@@ -1,0 +1,114 @@
+//
+//  LinkedinShare.m
+//  RNShare
+//
+//  Created by Ralf Nieuwenhuizen on 12-04-17.
+//
+
+#import "LinkedinShare.h"
+#import <AVFoundation/AVFoundation.h>
+@import Photos;
+
+@implementation LinkedinShare
+    RCT_EXPORT_MODULE();
+- (void)shareSingle:(NSDictionary *)options
+    reject:(RCTPromiseRejectBlock)reject
+    resolve:(RCTPromiseResolveBlock)resolve {
+    
+    NSLog(@"Try open view");
+    
+    NSString *url = [NSString stringWithFormat:@"https://www.linkedin.com/shareArticle/?url=%@", options[@"url"]];
+    NSURL *shareURL = [NSURL URLWithString:[url stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+
+  if ([[UIApplication sharedApplication] canOpenURL: shareURL]) {
+      [[UIApplication sharedApplication] openURL:shareURL];
+      resolve(@[@true, @""]);
+    } else {
+        // Cannot open Linkedin
+        NSString *stringURL = @"https://apps.apple.com/us/app/linkedin-network-job-finder/id288429040";
+        NSURL *url = [NSURL URLWithString:stringURL];
+        
+        [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:^(BOOL success) {}];
+        
+        NSString *errorMessage = @"Not installed";
+        NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};
+        NSError *error = [NSError errorWithDomain:@"com.rnshare" code:1 userInfo:userInfo];
+        
+        NSLog(@"%@", errorMessage);
+        reject(@"com.rnshare",@"Not installed",error);
+    }
+}
+
+- (void)shareSingleImage:(NSDictionary *)options
+         reject:(RCTPromiseRejectBlock)reject
+         resolve:(RCTPromiseResolveBlock)resolve {
+    
+    UIImage *image;
+    NSURL *imageURL = [RCTConvert NSURL:options[@"url"]];
+    if (imageURL) {
+        if (imageURL.fileURL || [imageURL.scheme.lowercaseString isEqualToString:@"data"]) {
+            NSError *error;
+            NSData *data = [NSData dataWithContentsOfURL:imageURL
+                                                 options:(NSDataReadingOptions)0
+                                                   error:&error];
+            if (!data) {
+                reject(@"com.rnshare",@"no data",error);
+                return;
+            }
+            image = [UIImage imageWithData: data];
+            [self savePictureAndOpenLinkedin: image
+                              reject: reject
+                              resolve: resolve];
+        }
+    } else {
+        [[UIApplication sharedApplication] openURL: [NSURL URLWithString:@"linkedin://camera"]];
+        resolve(@[@true, @""]);
+    }
+}
+
+-(void)savePictureAndOpenLinkedin:(UIImage *)base64Image
+                   reject:(RCTPromiseRejectBlock)reject
+                   resolve:(RCTPromiseResolveBlock)resolve {
+    
+    NSURL *URL = [self fileURLWithTemporaryImageData:UIImageJPEGRepresentation(base64Image, 0.9)];
+    __block PHAssetChangeRequest *_mChangeRequest = nil;
+    __block PHObjectPlaceholder *placeholder;
+    
+    [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
+        
+        NSData *pngData = [NSData dataWithContentsOfURL:URL];
+        UIImage *image = [UIImage imageWithData:pngData];
+        _mChangeRequest = [PHAssetChangeRequest creationRequestForAssetFromImage:image];
+        placeholder = _mChangeRequest.placeholderForCreatedAsset;
+    } completionHandler:^(BOOL success, NSError *error) {
+        
+        if (success) {
+            NSURL *LinkedinURL = [NSURL URLWithString:[NSString stringWithFormat:@"linkedin://library?LocalIdentifier=\%@", [placeholder localIdentifier]]];
+            
+            if ([[UIApplication sharedApplication] canOpenURL:LinkedinURL]) {
+                if (@available(iOS 10.0, *)) {
+                    [[UIApplication sharedApplication] openURL:LinkedinURL options:@{} completionHandler:NULL];
+                }
+                if (resolve != NULL) {
+                    resolve(@[@true, @""]);
+                }
+            }
+        }
+        else {
+            //Error while writing
+            if (reject != NULL) {
+                reject(@"com.rnshare",@"error",error);
+            }
+        }
+    }];
+}
+
+- (NSURL *)fileURLWithTemporaryImageData:(NSData *)data {
+    NSString *writePath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"linkedin"];
+    if (![data writeToFile:writePath atomically:YES]) {
+        return nil;
+    }
+    return [NSURL fileURLWithPath:writePath];
+}
+
+@end

--- a/ios/RNShare.mm
+++ b/ios/RNShare.mm
@@ -14,6 +14,7 @@
 #import "WhatsAppShare.h"
 #import "InstagramShare.h"
 #import "InstagramStories.h"
+#import "LinkedinShare.h"
 #import "FacebookStories.h"
 #import "GooglePlusShare.h"
 #import "EmailShare.h"
@@ -148,7 +149,11 @@ RCT_EXPORT_METHOD(shareSingle:(NSDictionary *)options
             NSLog(@"TRY OPEN instagram-stories");
             InstagramStories *shareCtl = [[InstagramStories alloc] init];
             [shareCtl shareSingle:options reject: reject resolve: resolve];
-         } else if([social isEqualToString:@"telegram"]) {
+         } else if([social isEqualToString:@"linkedin"]) {
+           NSLog(@"TRY OPEN linkedin");
+           LinkedinShare *shareCtl = [[LinkedinShare alloc] init];
+           [shareCtl shareSingle:options reject: reject resolve: resolve];
+        } else if([social isEqualToString:@"telegram"]) {
             NSLog(@"TRY OPEN telegram");
             TelegramShare *shareCtl = [[TelegramShare alloc] init];
             [shareCtl shareSingle:options reject: reject resolve: resolve];

--- a/ios/RNShare.xcodeproj/project.pbxproj
+++ b/ios/RNShare.xcodeproj/project.pbxproj
@@ -13,8 +13,9 @@
 		B33C22851D441713006BCD98 /* GenericShare.m in Sources */ = {isa = PBXBuildFile; fileRef = B33C22841D441713006BCD98 /* GenericShare.m */; };
 		B33C22891D4419E8006BCD98 /* WhatsAppShare.m in Sources */ = {isa = PBXBuildFile; fileRef = B33C22881D4419E8006BCD98 /* WhatsAppShare.m */; };
 		B33C228B1D442577006BCD98 /* EmailShare.m in Sources */ = {isa = PBXBuildFile; fileRef = B33C228A1D442576006BCD98 /* EmailShare.m */; };
-		B3E7B58A1CC2AC0600A0062D /* RNShare.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* RNShare.m */; };
+		B3E7B58A1CC2AC0600A0062D /* RNShare.mm in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* RNShare.mm */; };
 		B3EEE48E1D4844E7008422B6 /* GooglePlusShare.m in Sources */ = {isa = PBXBuildFile; fileRef = B3EEE48D1D4844E7008422B6 /* GooglePlusShare.m */; };
+		CD4EBD382A8927D3004CB598 /* LinkedinShare.m in Sources */ = {isa = PBXBuildFile; fileRef = CD4EBD362A8927D3004CB598 /* LinkedinShare.m */; };
 		CE0C76371E9E7DE100ED396E /* InstagramShare.m in Sources */ = {isa = PBXBuildFile; fileRef = CE0C76361E9E7DE100ED396E /* InstagramShare.m */; };
 		F1A1AD582444B09B00E32E33 /* FacebookStories.m in Sources */ = {isa = PBXBuildFile; fileRef = F1A1AD572444B09B00E32E33 /* FacebookStories.m */; };
 		FCC7BB4F221457EF00E1EA39 /* InstagramStories.m in Sources */ = {isa = PBXBuildFile; fileRef = FCC7BB4E221457EF00E1EA39 /* InstagramStories.m */; };
@@ -47,9 +48,11 @@
 		B33C228A1D442576006BCD98 /* EmailShare.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EmailShare.m; sourceTree = "<group>"; };
 		B33C228C1D442583006BCD98 /* EmailShare.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EmailShare.h; sourceTree = "<group>"; };
 		B3E7B5881CC2AC0600A0062D /* RNShare.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNShare.h; sourceTree = "<group>"; };
-		B3E7B5891CC2AC0600A0062D /* RNShare.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNShare.m; sourceTree = "<group>"; };
+		B3E7B5891CC2AC0600A0062D /* RNShare.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RNShare.mm; sourceTree = "<group>"; };
 		B3EEE48D1D4844E7008422B6 /* GooglePlusShare.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GooglePlusShare.m; sourceTree = "<group>"; };
 		B3EEE48F1D4844F4008422B6 /* GooglePlusShare.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GooglePlusShare.h; sourceTree = "<group>"; };
+		CD4EBD362A8927D3004CB598 /* LinkedinShare.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LinkedinShare.m; sourceTree = "<group>"; };
+		CD4EBD372A8927D3004CB598 /* LinkedinShare.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LinkedinShare.h; sourceTree = "<group>"; };
 		CE0C76361E9E7DE100ED396E /* InstagramShare.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = InstagramShare.m; sourceTree = "<group>"; };
 		CE0C76621E9E869300ED396E /* InstagramShare.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InstagramShare.h; sourceTree = "<group>"; };
 		F1A1AD562444B09B00E32E33 /* FacebookStories.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FacebookStories.h; sourceTree = "<group>"; };
@@ -82,7 +85,7 @@
 			children = (
 				B33C22801D43F9B0006BCD98 /* social */,
 				B3E7B5881CC2AC0600A0062D /* RNShare.h */,
-				B3E7B5891CC2AC0600A0062D /* RNShare.m */,
+				B3E7B5891CC2AC0600A0062D /* RNShare.mm */,
 				6D697F8223A86EBC00F754A1 /* RNShareActivityItemSource.h */,
 				6D697F8323A86EBC00F754A1 /* RNShareActivityItemSource.m */,
 				134814211AA4EA7D00B7C361 /* Products */,
@@ -104,6 +107,8 @@
 				CE0C76361E9E7DE100ED396E /* InstagramShare.m */,
 				FCC7BB4D2214566C00E1EA39 /* InstagramStories.h */,
 				FCC7BB4E221457EF00E1EA39 /* InstagramStories.m */,
+				CD4EBD372A8927D3004CB598 /* LinkedinShare.h */,
+				CD4EBD362A8927D3004CB598 /* LinkedinShare.m */,
 				6513A53728AF108500F0AE09 /* MessengerShare.h */,
 				6513A53828AF109A00F0AE09 /* MessengerShare.m */,
 				65B4E1B828AF0DB400D905B8 /* RNShareUtils.h */,
@@ -176,12 +181,13 @@
 				6D697F8423A86EBC00F754A1 /* RNShareActivityItemSource.m in Sources */,
 				CE0C76371E9E7DE100ED396E /* InstagramShare.m in Sources */,
 				B3EEE48E1D4844E7008422B6 /* GooglePlusShare.m in Sources */,
-				B3E7B58A1CC2AC0600A0062D /* RNShare.m in Sources */,
+				B3E7B58A1CC2AC0600A0062D /* RNShare.mm in Sources */,
 				B33C22891D4419E8006BCD98 /* WhatsAppShare.m in Sources */,
 				B33C228B1D442577006BCD98 /* EmailShare.m in Sources */,
 				FCC7BB4F221457EF00E1EA39 /* InstagramStories.m in Sources */,
 				6513A53928AF109A00F0AE09 /* MessengerShare.m in Sources */,
 				B33C22851D441713006BCD98 /* GenericShare.m in Sources */,
+				CD4EBD382A8927D3004CB598 /* LinkedinShare.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
# Overview
This allows sharing of basic urls to the Linkedin mobile app for iOS.

# Test Plan
If you simply pass `{ url }` as the `ShareOptions` to `shareSingle` along with `Social.Linkedin`, this will automatically open in the Linkedin application for sharing. Will add another PR for sharing images.

```typescript
await Share.shareSingle({ 
   appId: 'com.linkedin',
   social: Social.Linkedin,
   url: 'https://readless.ai/read?s=47781',
});
```

![IMG_3556](https://github.com/react-native-share/react-native-share/assets/14790443/7d7e4b94-3258-4c51-81dc-094ebd05c2e3)


