### PR TITLE
Share.open not returning promise in Android

### DIFF
--- a/android/src/main/java/cl/json/RNShareImpl.java
+++ b/android/src/main/java/cl/json/RNShareImpl.java
@@ -55,13 +55,16 @@ public class RNShareImpl implements ActivityEventListener {
                 WritableMap reply = Arguments.createMap();
                 reply.putBoolean("success", false);
                 reply.putString("message", "CANCELED");
+                TargetChosenReceiver.callbackResolve(reply);
             } else if (resultCode == Activity.RESULT_OK) {
                 WritableMap reply = Arguments.createMap();
                 reply.putBoolean("success", true);
+                TargetChosenReceiver.callbackResolve(reply);
             }
         }
     }
-
+    
+    @Override
     public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
         onActivityResult(requestCode, resultCode, data);
     }


### PR DESCRIPTION
# Overview

`Share.open` is not returning promise in Android.

Callback resolve call added to `RNShareImpl` to close the cycle.

(Might) close #1405 

# Test Plan

Help wanted.
