### PR TITLE
feat(ios): support sms share

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -16,6 +16,7 @@ import {
   Text,
   View,
   ScrollView,
+  SafeAreaView,
 } from 'react-native';
 
 import Share from 'react-native-share';
@@ -62,8 +63,8 @@ const App = () => {
     const shareOptions = {
       title: 'Share file',
       message: 'Simple share with message',
-      url: 'https://google.com'
-    }
+      url: 'https://google.com',
+    };
 
     try {
       const ShareResponse = await Share.open(shareOptions);
@@ -73,7 +74,7 @@ const App = () => {
       console.log('Error =>', error);
       setResult('error: '.concat(getErrorString(error)));
     }
-  }
+  };
 
   /**
    * This functions share multiple images that
@@ -359,9 +360,11 @@ const App = () => {
   };
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.welcome}>Welcome to React Native Share Example!</Text>
-      <ScrollView contentContainerStyle={styles.optionsRow}>
+    <SafeAreaView style={styles.container}>
+      <ScrollView showsVerticalScrollIndicator={false}>
+        <Text style={styles.welcome}>
+          Welcome to React Native Share Example!
+        </Text>
         <View style={styles.button}>
           <Button onPress={shareUrlWithMessage} title="Share Simple Url" />
         </View>
@@ -370,6 +373,18 @@ const App = () => {
         </View>
         <View style={styles.button}>
           <Button onPress={shareSingleImage} title="Share Single Image" />
+        </View>
+        <View style={styles.withInputContainer}>
+          <TextInput
+            placeholder="Recipient"
+            onChangeText={setRecipient}
+            value={recipient}
+            style={styles.textInput}
+            keyboardType="number-pad"
+          />
+          <View>
+            <Button onPress={shareSms} title="Share via SMS" />
+          </View>
         </View>
         <View style={styles.button}>
           <Button onPress={shareEmailImage} title="Share Social: Email" />
@@ -413,18 +428,6 @@ const App = () => {
             </View>
             <View style={styles.withInputContainer}>
               <TextInput
-                placeholder="Recipient"
-                onChangeText={setRecipient}
-                value={recipient}
-                style={styles.textInput}
-                keyboardType="number-pad"
-              />
-              <View>
-                <Button onPress={shareSms} title="Share Social: SMS" />
-              </View>
-            </View>
-            <View style={styles.withInputContainer}>
-              <TextInput
                 placeholder="Search for a Package"
                 onChangeText={setPackageSearch}
                 value={packageSearch}
@@ -442,7 +445,7 @@ const App = () => {
         <Text style={styles.resultTitle}>Result</Text>
         <Text style={styles.result}>{result}</Text>
       </ScrollView>
-    </View>
+    </SafeAreaView>
   );
 };
 
@@ -476,7 +479,7 @@ const styles = StyleSheet.create({
   },
   optionsRow: {
     justifyContent: 'space-between',
-    width: '80%'
+    width: '80%',
   },
   withInputContainer: {
     alignItems: 'center',

--- a/ios/RNShare.mm
+++ b/ios/RNShare.mm
@@ -94,7 +94,7 @@ RCT_EXPORT_MODULE()
     @"EMAIL": @"email",
     @"MESSENGER": @"messanger",
     @"VIBER": @"viber",
-
+    @"SMS": @"sms",
     @"SHARE_BACKGROUND_IMAGE": @"shareBackgroundImage",
     @"SHARE_BACKGROUND_VIDEO": @"shareBackgroundVideo",
     @"SHARE_STICKER_IMAGE": @"shareStickerImage",

--- a/ios/RNShare.mm
+++ b/ios/RNShare.mm
@@ -20,6 +20,7 @@
 #import "TelegramShare.h"
 #import "ViberShare.h"
 #import "MessengerShare.h"
+#import "SmsShare.h"
 #import "RNShareActivityItemSource.h"
 #import "RNShareUtils.h"
 
@@ -36,6 +37,7 @@ RCTPromiseResolveBlock resolveBlock;
 // may implement a delegate and could be garbage collected
 // before it is called
 EmailShare *shareCtl;
+SmsShare *smsShareCtl;
 
 - (dispatch_queue_t)methodQueue
 {
@@ -51,6 +53,7 @@ EmailShare *shareCtl;
 {
     if ((self = [super init])) {
         shareCtl = [[EmailShare alloc] init];
+        smsShareCtl = [[SmsShare alloc] init];
     }
     return self;
 }
@@ -163,6 +166,9 @@ RCT_EXPORT_METHOD(shareSingle:(NSDictionary *)options
             NSLog(@"TRY OPEN messenger");
             MessengerShare *shareCtl = [[MessengerShare alloc] init];
             [shareCtl shareSingle:options reject: reject resolve: resolve];
+        } else if([social isEqualToString:@"sms"]) {
+            NSLog(@"TRY OPEN sms");
+            [smsShareCtl shareSingle:options reject: reject resolve: resolve];
         }
     } else {
         RCTLogError(@"key 'social' missing in options");

--- a/ios/RNShare.xcodeproj/project.pbxproj
+++ b/ios/RNShare.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		6513A53928AF109A00F0AE09 /* MessengerShare.m in Sources */ = {isa = PBXBuildFile; fileRef = 6513A53828AF109A00F0AE09 /* MessengerShare.m */; };
 		65B4E1BA28AF0DC800D905B8 /* RNShareUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B4E1B928AF0DC800D905B8 /* RNShareUtils.m */; };
 		6D697F8423A86EBC00F754A1 /* RNShareActivityItemSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D697F8323A86EBC00F754A1 /* RNShareActivityItemSource.m */; };
+		962C1A3C2A8A714D0046A9E0 /* SmsShare.m in Sources */ = {isa = PBXBuildFile; fileRef = 962C1A3B2A8A714D0046A9E0 /* SmsShare.m */; };
 		B33C22851D441713006BCD98 /* GenericShare.m in Sources */ = {isa = PBXBuildFile; fileRef = B33C22841D441713006BCD98 /* GenericShare.m */; };
 		B33C22891D4419E8006BCD98 /* WhatsAppShare.m in Sources */ = {isa = PBXBuildFile; fileRef = B33C22881D4419E8006BCD98 /* WhatsAppShare.m */; };
 		B33C228B1D442577006BCD98 /* EmailShare.m in Sources */ = {isa = PBXBuildFile; fileRef = B33C228A1D442576006BCD98 /* EmailShare.m */; };
@@ -40,6 +41,8 @@
 		65B4E1B928AF0DC800D905B8 /* RNShareUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNShareUtils.m; sourceTree = "<group>"; };
 		6D697F8223A86EBC00F754A1 /* RNShareActivityItemSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNShareActivityItemSource.h; sourceTree = "<group>"; };
 		6D697F8323A86EBC00F754A1 /* RNShareActivityItemSource.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNShareActivityItemSource.m; sourceTree = "<group>"; };
+		962C1A3A2A8A71400046A9E0 /* SmsShare.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SmsShare.h; sourceTree = "<group>"; };
+		962C1A3B2A8A714D0046A9E0 /* SmsShare.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SmsShare.m; sourceTree = "<group>"; };
 		B33C22841D441713006BCD98 /* GenericShare.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GenericShare.m; sourceTree = "<group>"; };
 		B33C22861D441723006BCD98 /* GenericShare.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GenericShare.h; sourceTree = "<group>"; };
 		B33C22871D4419DA006BCD98 /* WhatsAppShare.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WhatsAppShare.h; sourceTree = "<group>"; };
@@ -110,6 +113,8 @@
 				65B4E1B928AF0DC800D905B8 /* RNShareUtils.m */,
 				B33C22871D4419DA006BCD98 /* WhatsAppShare.h */,
 				B33C22881D4419E8006BCD98 /* WhatsAppShare.m */,
+				962C1A3A2A8A71400046A9E0 /* SmsShare.h */,
+				962C1A3B2A8A714D0046A9E0 /* SmsShare.m */,
 			);
 			name = social;
 			sourceTree = "<group>";
@@ -178,6 +183,7 @@
 				B3EEE48E1D4844E7008422B6 /* GooglePlusShare.m in Sources */,
 				B3E7B58A1CC2AC0600A0062D /* RNShare.m in Sources */,
 				B33C22891D4419E8006BCD98 /* WhatsAppShare.m in Sources */,
+				962C1A3C2A8A714D0046A9E0 /* SmsShare.m in Sources */,
 				B33C228B1D442577006BCD98 /* EmailShare.m in Sources */,
 				FCC7BB4F221457EF00E1EA39 /* InstagramStories.m in Sources */,
 				6513A53928AF109A00F0AE09 /* MessengerShare.m in Sources */,

--- a/ios/SmsShare.h
+++ b/ios/SmsShare.h
@@ -1,0 +1,16 @@
+#import <UIKit/UIKit.h>
+// import RCTConvertttt
+#import <React/RCTConvert.h>
+// import RCTBridge
+#import <React/RCTBridge.h>
+// import RCTUIManager
+#import <React/RCTUIManager.h>
+// import RCTLog
+#import <React/RCTLog.h>
+// import RCTUtils
+#import <React/RCTUtils.h>
+#import <MessageUI/MessageUI.h>
+@interface SmsShare : NSObject <MFMessageComposeViewControllerDelegate>
+
+- (void) shareSingle:(NSDictionary *)options reject:(RCTPromiseRejectBlock)reject resolve:(RCTPromiseResolveBlock)resolve;
+@end

--- a/ios/SmsShare.m
+++ b/ios/SmsShare.m
@@ -1,0 +1,51 @@
+#import "SmsShare.h"
+#import "RNShareUtils.h"
+
+
+@implementation SmsShare
+
+
+- (void)shareSingle:(NSDictionary *)options
+    reject:(RCTPromiseRejectBlock)reject
+    resolve:(RCTPromiseResolveBlock)resolve {
+
+    if ([options objectForKey:@"message"] && [options objectForKey:@"message"] != [NSNull null]) {
+
+        NSString *message = [RCTConvert NSString:options[@"message"]];
+        NSString *recipient = [RCTConvert NSString:options[@"recipient"]];
+        
+        if (![MFMessageComposeViewController canSendText]) {
+            NSString *errorMessage = @"Sms services is not available.";
+            NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};
+            NSError *error = [NSError errorWithDomain:@"com.rnshare" code:1 userInfo:userInfo];
+            reject(@"com.rnshare", errorMessage, error);
+            return;
+        }
+
+        MFMessageComposeViewController *mc = [[MFMessageComposeViewController alloc] init];
+        mc.messageComposeDelegate = self;
+
+        NSMutableArray *recipients = [[NSMutableArray alloc] init];
+        if (![recipient  isEqual: @""]) {
+            [recipients addObject:recipient];
+        }
+        mc.recipients = recipients;
+        mc.body = message;
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            UIViewController *ctrl = RCTPresentedViewController();
+            [ctrl presentViewController:mc animated:YES completion:NULL];
+            resolve(@[@true, @""]);
+        });
+    }
+}
+
+- (void)messageComposeViewController:(MFMessageComposeViewController *)controller
+                 didFinishWithResult:(MessageComposeResult)result {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIViewController *ctrl = RCTPresentedViewController();
+        [ctrl dismissViewControllerAnimated:YES completion:NULL];
+    });
+}
+
+@end

--- a/ios/SmsShare.m
+++ b/ios/SmsShare.m
@@ -31,6 +31,36 @@
         }
         mc.recipients = recipients;
         mc.body = message;
+        
+        NSURL *URL = [RCTConvert NSURL:options[@"url"]];
+        if (URL) {
+            BOOL isDataScheme = [URL.scheme.lowercaseString isEqualToString:@"data"];
+    
+            // Only handling data scheme urls here. To handle the case of URL.isFileURL
+            // one could add a case similar to the process in EmailShare.m
+            if (isDataScheme) {
+                NSError *error;
+                NSData *data = [NSData dataWithContentsOfURL:URL
+                                                     options:(NSDataReadingOptions)0
+                                                       error:&error];
+                if (!data) {
+                    reject(@"com.rnshare", @"No data", error);
+                    return;
+                }
+    
+                NSURL *filePath = [RNShareUtils getPathFromBase64:URL.absoluteString with:data fileName:@"file"];
+                if (filePath) {
+                    // public.image typeIdentifier works for both images and files
+                    [mc addAttachmentData:data typeIdentifier:@"public.image" filename:filePath.absoluteString];
+                }
+            } else {
+                // if not a file, just append URL to message
+                NSString *urlString = [RCTConvert NSString:options[@"url"]];
+                message = [message stringByAppendingString: [@" " stringByAppendingString:  urlString]];
+                [mc setBody:message];
+            }
+        }
+
 
         dispatch_async(dispatch_get_main_queue(), ^{
             UIViewController *ctrl = RCTPresentedViewController();

--- a/website/docs/share-single.mdx
+++ b/website/docs/share-single.mdx
@@ -65,7 +65,7 @@ You can pass the option that will be handled by the native code, similar to `Sha
 | title              | string   | Title sent to the share activity                                                                                                                 | ✅       | ✅      | ✅  | ❓      |
 | subject            | string   | Subject sent when sharing to email                                                                                                               | ✅       | ✅      | ✅  | ❓      |
 | email              | string   | Email of addressee                                                                                                                               | ✅       | ✅      | ✅  | ❓      |
-| recipient          | string   | Phone number of SMS recipient                                                                                                                    | ✅       | ✅      | 🚫  | 🚫      |
+| recipient          | string   | Phone number of SMS recipient                                                                                                                    | ✅       | ✅      | ✅ | 🚫      |
 | social             | string   | supported social apps: [List](#supported-applications)                                                                                         | 🚫       | ✅      | ✅  | ❓      |
 | forceDialog        | boolean  | (optional) only android. Avoid showing dialog with buttons Just Once / Always. Useful for Instagram to always ask user if share as Story or Feed | ✅       | ✅      | ✅  | ❓      |
 | useInternalStorage | boolean  | Store the temporary file in the internal storage cache (Android only)                                                                            | ✅       | ✅      | 🚫  | 🚫      |
@@ -88,7 +88,7 @@ You can pass the option that will be handled by the native code, similar to `Sha
 | **GOOGLEPLUS**        |   ✅    | ✅  | 🚫      |
 | **EMAIL**             |   ✅    | ✅  | 🚫      |
 | **PINTEREST**         |   ✅    | 🚫  | 🚫      |
-| **SMS**               |   ✅    | 🚫  | 🚫      |
+| **SMS**               |   ✅    | ✅  | 🚫      |
 | **SNAPCHAT**          |   ✅    | 🚫  | 🚫      |
 | **MESSENGER**         |   ✅    | ✅  | 🚫      |
 | **LINKEDIN**          |   ✅    | 🚫  | 🚫      |


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

This PR expands on the work done by @ku8ar https://github.com/react-native-share/react-native-share/pull/1447 and adds:

1. Support for passing url as options 
2. Updates docs
3. Adds iOS Sms shareSingle usage in example app
4. Includes sms in exported constants


# Test Plan

Build locally and run the example app. 

**Demo of Exampe App**

https://github.com/react-native-share/react-native-share/assets/20777666/faffe1d1-8620-480f-9553-fc3b8fe5e5d2

**Demo of URL option in our app that uses this library**

https://github.com/react-native-share/react-native-share/assets/20777666/179e1d63-221e-44ff-a55b-fd5c1a20389c
