### PR TITLE
chore(ci): update to supported xcode version 13.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
 
   ios_build:
     macos:
-      xcode: 13.2.1
+      xcode: 13.4.1
     working_directory: ~/app
     steps:
       - checkout


### PR DESCRIPTION
# Overview

 Noticed in [this PR](https://github.com/react-native-share/react-native-share/pull/1456) that iOS build fails on CI due to `as rejected because resource class medium, image xcode:13.2.1 is not a valid resource class`. This updates to supported Xcode version according [to here](https://circleci.com/docs/using-macos/#supported-xcode-versions). 

# Test Plan
iOS Builds.
