### PR TITLE
feat(android): add namespace to support AGP 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,7 @@ if (isNewArchitectureEnabled()) {
 }
 
 android {
+    namespace = "cl.json"
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)


### PR DESCRIPTION
# Overview
Trivial change to support AGP 8 as mentioned here: https://github.com/react-native-community/discussions-and-proposals/issues/671

Nicola mentioned also we shouldn't remove package attribute from AndroidManifest to not lose compatibility with AGP < 8. I don't think it's worth maintaining logic to remove that attribute contitionally since it will only cause a warning to users on AGP 8 and above. 

ps: [I acknowledged someone else](https://github.com/react-native-share/react-native-share/pull/1401) already tried this change but they remove package attribute which is not ideal.
# Test Plan

I did not build this locally since it's a trivial attribute addition. 