### PR TITLE
fix(ios): fixed typo in RNShare.mm file

### DIFF
--- a/ios/RNShare.mm
+++ b/ios/RNShare.mm
@@ -92,7 +92,7 @@ RCT_EXPORT_MODULE()
     @"INSTAGRAMSTORIES": @"instagramstories",
     @"TELEGRAM": @"telegram",
     @"EMAIL": @"email",
-    @"MESSENGER": @"messanger",
+    @"MESSENGER": @"messenger",
     @"VIBER": @"viber",
     @"SMS": @"sms",
     @"SHARE_BACKGROUND_IMAGE": @"shareBackgroundImage",


### PR DESCRIPTION
The messenger share functionality is not working properly due to the typo issue we made here.

# Overview
The share functionality of Messenger is not working on iOS due to the condition mismatch and have analysed the code and found we made a typo in the constants file. Have fixed it. Kindly review and share feedback.


# Test Plan
I did not build this locally since it's trivial.
