### PR TITLE
fix(ios): Build fail in New Architecture

### DIFF
--- a/ios/RNShare.h
+++ b/ios/RNShare.h
@@ -9,7 +9,7 @@
 #endif
 
 #if RCT_NEW_ARCH_ENABLED
-#import <React-Codegen/RNShareSpec/RNShareSpec.h>
+#import <RNShareSpec/RNShareSpec.h>
 #endif
 
 @interface RNShare : NSObject <RCTBridgeModule, UIDocumentPickerDelegate>


### PR DESCRIPTION
# Overview
This fixes an IOS compile error with the new architecture. [1232](https://github.com/react-native-share/react-native-share/issues/1232)
