### PR TITLE
[Android] Add support for Bridgeless Mode - 0.74

### DIFF
--- a/android/src/main/java/cl/json/RNSharePackage.java
+++ b/android/src/main/java/cl/json/RNSharePackage.java
@@ -36,7 +36,7 @@ public class RNSharePackage extends TurboReactPackage {
                             false, // needsEagerInit
                             true, // hasConstants
                             false, // isCxxModule
-                            false // isTurboModule
+                            true // isTurboModule
             ));
             return moduleInfos;
         };


### PR DESCRIPTION
# Overview
I've been testing Bridgeless mode in 0.74 RC3 and realized that the library is broken on Android. Here the fix

# Test Plan
| Before | After |
| ------ | ----- |
| ![untitled2](https://github.com/react-native-share/react-native-share/assets/3001957/07265363-3403-4be9-ae9c-971511c55716) | ![untitled](https://github.com/react-native-share/react-native-share/assets/3001957/30f7bf25-3f86-4130-a5c0-7eb73c7a523f) |


