### PR TITLE
chore(ci): Fix failing build-lint-app workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 
 orbs:
-  react-native: react-native-community/react-native@7.1.1
+  react-native: react-native-community/react-native@7.4.0
 
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,12 @@ jobs:
       - checkout_attach_workspace
       - react-native/setup_macos_executor:
           node_version: '18.17.1'
+          android: false
+          detox: false
       - react-native/yarn_install
+      - run:
+        name: Install Detox
+        command: npm install detox-cli --global
       - restore_cache:
           keys:
             - >-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,8 +109,8 @@ jobs:
           detox: false
       - react-native/yarn_install
       - run:
-        name: Install Detox
-        command: npm install detox-cli --global
+          name: Install Detox
+          command: npm install detox-cli --global
       - restore_cache:
           keys:
             - >-


### PR DESCRIPTION
# Overview

CI is currently failing on iOS. I'm not super familiar with this CI setup, but I bumped the orb version to see if that would help. It didn't. It looks like the orb is still configured to use brew casks in a couple places, which will error on recent versions of homebrew. Additionally, we were spending some unnecessary compute minutes installing Android tools on the macOS executor that is only responsible for building for iOS. I also switched to using npm to install Detox, as they recommend in their docs, but this isn't really necessary since the job doesn't actually use Detox.

# Test Plan

Let CI run
