### PR TITLE
feat: support discord share for android and ios

### DIFF
--- a/android/src/main/java/cl/json/RNShareImpl.java
+++ b/android/src/main/java/cl/json/RNShareImpl.java
@@ -34,6 +34,7 @@ import cl.json.social.SMSShare;
 import cl.json.social.MessengerShare;
 import cl.json.social.LinkedinShare;
 import cl.json.social.ViberShare;
+import cl.json.social.DiscordShare;
 
 import java.util.HashMap;
 import java.util.Locale;
@@ -90,7 +91,8 @@ public class RNShareImpl implements ActivityEventListener {
         sms,
         linkedin,
         telegram,
-        viber;
+        viber,
+        discord;
 
 
         public static ShareIntent getShareClass(String social, ReactApplicationContext reactContext) {
@@ -132,6 +134,8 @@ public class RNShareImpl implements ActivityEventListener {
                     return new TelegramShare(reactContext);
                 case viber:
                     return new ViberShare(reactContext);
+                case discord:
+                    return new DiscordShare(reactContext);
                 default:
                     return null;
             }

--- a/android/src/main/java/cl/json/social/DiscordShare.java
+++ b/android/src/main/java/cl/json/social/DiscordShare.java
@@ -1,0 +1,43 @@
+package cl.json.social;
+
+import android.content.ActivityNotFoundException;
+import android.content.Intent;
+import java.io.File;
+import android.os.Environment;
+import android.net.Uri;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableMap;
+
+
+public class DiscordShare extends SingleShareIntent {
+
+    private static final String PACKAGE = "com.discord";
+    private static final String PLAY_STORE_LINK = "https://play.google.com/store/apps/details?id=com.discord";
+
+    public DiscordShare(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    @Override
+    public void open(ReadableMap options) throws ActivityNotFoundException {
+        super.open(options);
+        //  extra params here
+        this.openIntentChooser();
+    }
+
+    @Override
+    protected String getPackage() {
+        return PACKAGE;
+    }
+
+    @Override
+    protected String getDefaultWebLink() {
+        return null;
+    }
+
+    @Override
+    protected String getPlayStoreLink() {
+        return PLAY_STORE_LINK;
+    }
+}

--- a/codegenSpec/NativeRNShare.ts
+++ b/codegenSpec/NativeRNShare.ts
@@ -25,6 +25,7 @@ export interface Spec extends TurboModule {
     SHARE_BACKGROUND_AND_STICKER_IMAGE?: string;
     SMS?: string;
     GENERIC?: string;
+    DISCORD?: string;
   };
   open: (options: Object) => Promise<{ success: boolean; message: string }>;
   shareSingle: (options: Object) => Promise<{ success: boolean; message: string }>;

--- a/example/App.js
+++ b/example/App.js
@@ -343,6 +343,23 @@ const App = () => {
     }
   };
 
+  const shareToDiscord = async () => {
+    const shareOptions = {
+      message: 'Example Discord',
+      url: 'https://google.com',
+      social: Share.Social.DISCORD,
+    };
+
+    try {
+      const ShareResponse = await Share.shareSingle(shareOptions);
+      console.log('Response =>', ShareResponse);
+      setResult(JSON.stringify(ShareResponse, null, 2));
+    } catch (error) {
+      console.log('Error =>', error);
+      setResult('error: '.concat(getErrorString(error)));
+    }
+  };
+
   const sharePdfBase64 = async () => {
     const shareOptions = {
       title: '',
@@ -412,6 +429,9 @@ const App = () => {
         </View>
         <View style={styles.button}>
           <Button onPress={shareToWhatsApp} title="Share to WhatsApp" />
+        </View>
+        <View style={styles.button}>
+          <Button onPress={shareToDiscord} title="Share to Discord" />
         </View>
         <View style={styles.button}>
           <Button onPress={shareEmailImages} title="Share to Email" />

--- a/ios/DiscordShare.h
+++ b/ios/DiscordShare.h
@@ -1,0 +1,15 @@
+#import <UIKit/UIKit.h>
+// import RCTConvert
+#import <React/RCTConvert.h>
+// import RCTBridge
+#import <React/RCTBridge.h>
+// import RCTUIManager
+#import <React/RCTUIManager.h>
+// import RCTLog
+#import <React/RCTLog.h>
+// import RCTUtils
+#import <React/RCTUtils.h>
+@interface DiscordShare : NSObject <RCTBridgeModule>
+
+- (void) shareSingle:(NSDictionary *)options reject:(RCTPromiseRejectBlock)reject resolve:(RCTPromiseResolveBlock)resolve;
+@end

--- a/ios/DiscordShare.m
+++ b/ios/DiscordShare.m
@@ -1,0 +1,41 @@
+#import "DiscordShare.h"
+#import <AVFoundation/AVFoundation.h>
+@import Photos;
+
+@implementation DiscordShare
+    RCT_EXPORT_MODULE();
+- (void)shareSingle:(NSDictionary *)options
+    reject:(RCTPromiseRejectBlock)reject
+    resolve:(RCTPromiseResolveBlock)resolve {
+    
+    NSString *text = [RCTConvert NSString:options[@"message"]];
+    text = (NSString*)CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(NULL,(CFStringRef) text, NULL,CFSTR("!*'();:@&=+$,/?%#[]"),kCFStringEncodingUTF8));
+    
+    NSString *url = [RCTConvert NSString:options[@"url"]];
+    
+    NSString *discordMsg = [NSString stringWithFormat:@"discord://message?text=%@", text];
+    NSString *discordMsgUrl = [NSString stringWithFormat:@"discord://message?text=%@&url%@", text, url];
+
+    NSString * urlDiscord = url ? discordMsgUrl : discordMsg;
+    NSURL * shareURL = [NSURL URLWithString:urlDiscord];
+    
+    
+    if ([[UIApplication sharedApplication] canOpenURL: shareURL]) {
+        [[UIApplication sharedApplication] openURL: shareURL];
+        resolve(@[@true, @""]);
+    } else {
+        NSString *stringURL = @"https://apps.apple.com/us/app/discord-chat-talk-hangout/id985746746";
+        NSURL *url = [NSURL URLWithString:stringURL];
+        
+        [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:^(BOOL success) {}];
+        
+        NSString *errorMessage = @"Not installed";
+        NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};
+        NSError *error = [NSError errorWithDomain:@"com.rnshare" code:1 userInfo:userInfo];
+        
+        NSLog(@"%@", errorMessage);
+        reject(@"Not installed",@"Not installed",error);
+    }
+}
+
+@end

--- a/ios/RNShare.mm
+++ b/ios/RNShare.mm
@@ -21,6 +21,7 @@
 #import "ViberShare.h"
 #import "MessengerShare.h"
 #import "SmsShare.h"
+#import "DiscordShare.h"
 #import "RNShareActivityItemSource.h"
 #import "RNShareUtils.h"
 
@@ -95,6 +96,7 @@ RCT_EXPORT_MODULE()
     @"MESSENGER": @"messenger",
     @"VIBER": @"viber",
     @"SMS": @"sms",
+    @"DISCORD": @"discord",
     @"SHARE_BACKGROUND_IMAGE": @"shareBackgroundImage",
     @"SHARE_BACKGROUND_VIDEO": @"shareBackgroundVideo",
     @"SHARE_STICKER_IMAGE": @"shareStickerImage",
@@ -169,6 +171,10 @@ RCT_EXPORT_METHOD(shareSingle:(NSDictionary *)options
         } else if([social isEqualToString:@"sms"]) {
             NSLog(@"TRY OPEN sms");
             [smsShareCtl shareSingle:options reject: reject resolve: resolve];
+        } else if([social isEqualToString:@"discord"]) {
+            NSLog(@"TRY OPEN discord");
+            DiscordShare *shareCtl = [[DiscordShare alloc] init];
+            [shareCtl shareSingle:options reject: reject resolve: resolve];
         }
     } else {
         RCTLogError(@"key 'social' missing in options");

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,6 +42,7 @@ const RNShare = {
     MESSENGER: NativeRNShare.getConstants().MESSENGER || Social.Messenger,
     SNAPCHAT: NativeRNShare.getConstants().SNAPCHAT || Social.Snapchat,
     VIBER: NativeRNShare.getConstants().VIBER || Social.Viber,
+    DISCORD: NativeRNShare.getConstants().DISCORD || Social.Discord,
   },
 
   async open(options: ShareOptions) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export enum Social {
   Snapchat = 'snapchat',
   Messenger = 'messenger',
   Viber = 'viber',
+  Discord = 'discord',
 }
 
 export enum ShareAsset {


### PR DESCRIPTION
# Overview
Add discord share for both Android and IOS

# Test Plan
Add  share button in example project，there is a video of Android

https://github.com/react-native-share/react-native-share/assets/51528647/732a47df-7643-488d-b9cf-3db9a850eb3b
