### PR TITLE
refactor(ios): Improve WhatsAppShare readability

### DIFF
--- a/ios/WhatsAppShare.m
+++ b/ios/WhatsAppShare.m
@@ -8,87 +8,169 @@
 
 #import "WhatsAppShare.h"
 
+typedef NS_ENUM(NSInteger, MessageType) {
+  MessageTypeImage,
+  MessageTypeVideo,
+  MessageTypeText
+};
+
 @implementation WhatsAppShare
 static UIDocumentInteractionController *documentInteractionController;
 RCT_EXPORT_MODULE();
-- (void)shareSingle:(NSDictionary *)options
-    reject:(RCTPromiseRejectBlock)reject
-    resolve:(RCTPromiseResolveBlock)resolve {
+
+
+- (void) shareSingle:(NSDictionary *)options
+reject:(RCTPromiseRejectBlock)reject
+resolve:(RCTPromiseResolveBlock)resolve {
     
     NSLog(@"Try open view");
     
-    if ([options objectForKey:@"message"] && [options objectForKey:@"message"] != [NSNull null]) {
-        NSString *text = [RCTConvert NSString:options[@"message"]];
-        text = [text stringByAppendingString: [@" " stringByAppendingString: options[@"url"]] ];
-        NSString *whatsAppNumber = [RCTConvert NSString:options[@"whatsAppNumber"]];
-        
-        if ([[UIApplication sharedApplication] canOpenURL: [NSURL URLWithString:@"whatsapp://app"]]) {
-            NSLog(@"WhatsApp installed");
-        } else {
-            // Cannot open whatsapp
-            NSString *stringURL = @"https://itunes.apple.com/app/whatsapp-messenger/id310633997";
-            NSURL *url = [NSURL URLWithString:stringURL];
-            [[UIApplication sharedApplication] openURL:url];
-            
-            NSString *errorMessage = @"Not installed";
-            NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};
-            NSError *error = [NSError errorWithDomain:@"com.rnshare" code:1 userInfo:userInfo];
-            
-            NSLog(@"%@", errorMessage);
-            return reject(@"com.rnshare",@"Not installed",error);
-        }
-        
-        if ([options[@"url"] rangeOfString:@".wam"].location != NSNotFound || [options[@"url"] rangeOfString:@".mp4"].location != NSNotFound) {
-            NSLog(@"Sending whatsapp movie");
-            documentInteractionController = [UIDocumentInteractionController interactionControllerWithURL:[NSURL fileURLWithPath:options[@"url"]]];
-            documentInteractionController.UTI = @"net.whatsapp.movie";
-            documentInteractionController.delegate = self;
-            
-            [documentInteractionController presentOpenInMenuFromRect:CGRectZero inView:[[[[[UIApplication sharedApplication] delegate] window] rootViewController] view] animated:YES];
-            NSLog(@"Done whatsapp movie");
-            resolve(@[@true, @""]);
-        } else if ([options[@"url"] rangeOfString:@"png"].location != NSNotFound || [options[@"url"] rangeOfString:@"jpeg"].location != NSNotFound || [options[@"url"] rangeOfString:@"jpg"].location != NSNotFound || [options[@"url"] rangeOfString:@"gif"].location != NSNotFound) {
-            UIImage * image;
-            NSURL *imageURL = [RCTConvert NSURL:options[@"url"]];
-            if (imageURL) {
-                if (imageURL.fileURL || [imageURL.scheme.lowercaseString isEqualToString:@"data"]) {
-                    NSError *error;
-                    NSData *data = [NSData dataWithContentsOfURL:imageURL
-                                                         options:(NSDataReadingOptions)0
-                                                           error:&error];
-                    if (!data) {
-                        NSError *error = [NSError errorWithDomain:@"com.rnshare" code:2 userInfo:@{ NSLocalizedDescriptionKey:@"Something went wrong"}];
-                        return reject(@"com.rnshare",@"Something went wrong",error);
-                    }
-                    image = [UIImage imageWithData: data];
-                    NSString * documentsPath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0];
-                    NSString * filePath = [documentsPath stringByAppendingPathComponent:@"/whatsAppTmp.wai"];
-                    
-                    [UIImageJPEGRepresentation(image, 1.0) writeToFile:filePath atomically:YES];
-                    
-                    documentInteractionController = [UIDocumentInteractionController interactionControllerWithURL:[NSURL fileURLWithPath:filePath]];
-                    documentInteractionController.UTI = @"net.whatsapp.image";
-                    documentInteractionController.delegate = self;
-                    
-                    [documentInteractionController presentOpenInMenuFromRect:CGRectZero inView:[[[[[UIApplication sharedApplication] delegate] window] rootViewController] view] animated:YES];
-                    resolve(@[@true, @""]);
-                }
-            } else {
-                NSError *error = [NSError errorWithDomain:@"com.rnshare" code:3 userInfo:@{ NSLocalizedDescriptionKey:@"Something went wrong"}];
-                return reject(@"com.rnshare",@"Something went wrong",error);
-            }
-        } else {
-            text = (NSString*)CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(NULL,(CFStringRef) text, NULL,CFSTR("!*'();:@&=+$,/?%#[]"),kCFStringEncodingUTF8));
-            
-            NSString * urlWhats = whatsAppNumber ? [NSString stringWithFormat:@"whatsapp://send?phone=%@&text=%@", whatsAppNumber, text] : [NSString stringWithFormat:@"whatsapp://send?text=%@", text];
-            NSURL * whatsappURL = [NSURL URLWithString:urlWhats];
-            
-            if ([[UIApplication sharedApplication] canOpenURL: whatsappURL]) {
-                [[UIApplication sharedApplication] openURL: whatsappURL];
-                resolve(@[@true, @""]);
-            }
-        }
+    if(![self isAbleToSendMessage: options]){
+        return;
     }
+    
+    if(![self isWhatsAppavailable]) {
+        [self handleError:@"Not Installed" code:1 rejectFn:reject];
+        return;
+    }
+    
+    MessageType messageType = [self getMessageType: options[@"url"]];
+    
+    switch(messageType) {
+      case MessageTypeImage:
+        [self tryToSendImage: options resolve:resolve reject:reject];
+        break;
+        
+      case MessageTypeVideo:
+        [self tryToSendVideo: options resolve:resolve reject:reject];
+        break;
+        
+      default:
+        [self tryToSendText: options resolve:resolve reject:reject];
+    }
+    
+}
+
+-(void)tryToSendImage:(NSDictionary *)options
+              resolve:(RCTPromiseResolveBlock)resolve
+              reject:(RCTPromiseRejectBlock)reject {
+  UIImage *image;
+  NSURL *imageURL = [RCTConvert NSURL:options[@"url"]];
+  if(imageURL){
+    if (imageURL.fileURL || [imageURL.scheme.lowercaseString isEqualToString:@"data"]) {
+        NSError *error;
+        NSData *data = [NSData dataWithContentsOfURL:imageURL
+                                             options:(NSDataReadingOptions)0
+                                               error:&error];
+        if (!data) {
+          return [self handleError:@"Something went wrong" code:2 rejectFn:reject];
+        }
+      
+        image = [UIImage imageWithData: data];
+        NSString * documentsPath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0];
+        NSString * filePath = [documentsPath stringByAppendingPathComponent:@"/whatsAppTmp.wai"];
+        
+        [UIImageJPEGRepresentation(image, 1.0) writeToFile:filePath atomically:YES];
+      
+        [self shareMedia:filePath documentUTI:@"net.whatsapp.image"];
+      
+        resolve(@[@true, @""]);
+    }
+
+  }else {
+    [self handleError:@"Something went wrong" code:3 rejectFn:reject];
+  }
+  
+}
+
+-(void)tryToSendVideo:(NSDictionary *)options
+              resolve:(RCTPromiseResolveBlock)resolve
+              reject:(RCTPromiseRejectBlock)reject {
+  
+  NSLog(@"Sending whatsapp movie");
+  [self shareMedia:options[@"url"] documentUTI:@"net.whatsapp.movie"];
+  NSLog(@"Done whatsapp movie");
+  resolve(@[@true, @""]);
+}
+
+-(void)tryToSendText:(NSDictionary *)options
+             resolve:(RCTPromiseResolveBlock)resolve
+             reject:(RCTPromiseRejectBlock)reject {
+  
+  NSString *text = [RCTConvert NSString:options[@"message"]];
+  text = [text stringByAppendingString: [@" " stringByAppendingString: options[@"url"]] ];
+  NSString *whatsAppNumber = [RCTConvert NSString:options[@"whatsAppNumber"]];
+  
+  text = (NSString*)CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(NULL,(CFStringRef) text, NULL,CFSTR("!*'();:@&=+$,/?%#[]"),kCFStringEncodingUTF8));
+  
+  NSString * urlWhats = whatsAppNumber ? [NSString stringWithFormat:@"whatsapp://send?phone=%@&text=%@", whatsAppNumber, text] : [NSString stringWithFormat:@"whatsapp://send?text=%@", text];
+  NSURL * whatsappURL = [NSURL URLWithString:urlWhats];
+  
+  if ([[UIApplication sharedApplication] canOpenURL: whatsappURL]) {
+      [[UIApplication sharedApplication] openURL: whatsappURL];
+      resolve(@[@true, @""]);
+  }
+}
+
+
+-(MessageType)getMessageType: (NSString *)url {
+  NSArray *imageExtensions = @[@".png", @".jpeg",@".jpg",@".gif"];
+  if([self isMediaType:url mediaExtensions: imageExtensions]){
+    return MessageTypeImage;
+  }
+  
+  NSArray *videoExtensions = @[@".wam", @".mp4"];
+  if([self isMediaType:url mediaExtensions:videoExtensions]){
+    return MessageTypeVideo;
+  }
+  
+  return MessageTypeText;
+}
+
+-(BOOL)isMediaType:(NSString *)url mediaExtensions:(NSArray *)mediaExtensions {
+  for(NSString *extension in mediaExtensions){
+    if([url rangeOfString:extension].location != NSNotFound){
+      return TRUE;
+    }
+  }
+  return FALSE;
+}
+
+-(BOOL)isWhatsAppavailable {
+  if([[UIApplication sharedApplication] canOpenURL: [NSURL URLWithString:@"whatsapp://app"]]) {
+    NSLog(@"WhastApp installed");
+    return true;
+  }else {
+      // Cannot open whatsapp
+      NSString *appStoreStringURL = @"https://itunes.apple.com/app/whatsapp-messenger/id310633997";
+      NSURL *appStoreURL = [NSURL URLWithString:appStoreStringURL];
+      [[UIApplication sharedApplication] openURL:appStoreURL];
+      return false;
+  }
+}
+
+-(void)handleError:(NSString *)errorMessage code:(NSInteger)code rejectFn:(RCTPromiseRejectBlock)rejectFn {
+  NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};
+  NSError *error = [NSError errorWithDomain:@"com.rnshare" code:code userInfo:userInfo];
+  
+  NSLog(@"%@", errorMessage);
+  return rejectFn(@"com.rnshare",errorMessage,error);
+}
+
+
+-(BOOL)isAbleToSendMessage:(NSDictionary *) options {
+  if([options objectForKey:@"message"] && [options objectForKey:@"message"] != [NSNull null]){
+    return TRUE;
+  }
+  return FALSE;
+}
+
+-(void)shareMedia:(NSString *)stringURL documentUTI:(NSString *)documentUTI {
+  NSURL *filePath = [NSURL fileURLWithPath:stringURL];
+  documentInteractionController = [UIDocumentInteractionController interactionControllerWithURL:filePath];
+  documentInteractionController.UTI = documentUTI;
+  documentInteractionController.delegate = self;
+  [documentInteractionController presentOpenInMenuFromRect:CGRectZero inView:[[[[[UIApplication sharedApplication] delegate] window] rootViewController] view] animated:YES];
 }
 
 @end

--- a/ios/WhatsAppShare.m
+++ b/ios/WhatsAppShare.m
@@ -29,7 +29,7 @@ resolve:(RCTPromiseResolveBlock)resolve {
         return;
     }
     
-    if(![self isWhatsAppavailable]) {
+    if(![self isWhatsAppAvailable]) {
         [self handleError:@"Not Installed" code:1 rejectFn:reject];
         return;
     }
@@ -114,7 +114,7 @@ resolve:(RCTPromiseResolveBlock)resolve {
 
 
 -(MessageType)getMessageType: (NSString *)url {
-  NSArray *imageExtensions = @[@".png", @".jpeg",@".jpg",@".gif"];
+  NSArray *imageExtensions = @[@"png", @"jpeg",@"jpg",@"gif"];
   if([self isMediaType:url mediaExtensions: imageExtensions]){
     return MessageTypeImage;
   }
@@ -136,7 +136,7 @@ resolve:(RCTPromiseResolveBlock)resolve {
   return FALSE;
 }
 
--(BOOL)isWhatsAppavailable {
+-(BOOL)isWhatsAppAvailable {
   if([[UIApplication sharedApplication] canOpenURL: [NSURL URLWithString:@"whatsapp://app"]]) {
     NSLog(@"WhastApp installed");
     return true;


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

I've been using react-native-share for a while, and as part of my process to dive into native development, I decided to contribute to it. 

I had some difficulty understanding the logic behind the iOS WhastAppShare module, so this PR is a refactoring that applies a few clean code principles to improve the code's readability. 

- Create an ENUM to clarify what kind of data can be processed: Text, Image, and Video. 
- Split specific tasks in meaningful named functions: `tryToSendImage`, `isWhatsAppAvailable`, `getMessageType`, etc.
- Remove duplicated code by encapsulating it in reusable functions: `handleError,` `shareMedia`.

I'm willing to keep working on this kind of refactoring, but before spending more time I want to know if it is something you are interested in. 

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

I tested the refactoring by sending a text and an image, as you can see in the video below. Unfortunately, the video sharing wasn't working before my refactoring. Neither on WhatsApp or Instagram. Do you have any idea why? 

https://github.com/react-native-share/react-native-share/assets/12939735/04a0ee15-5142-414c-b9fe-a43d42b7c9ce



