### PR TITLE
fix: use proper way of deciding about new arch in podspec

### DIFF
--- a/RNShare.podspec
+++ b/RNShare.podspec
@@ -2,8 +2,6 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
-
 Pod::Spec.new do |s|
   s.name         = "RNShare"
   s.version      = package["version"]
@@ -16,24 +14,12 @@ Pod::Spec.new do |s|
 
   s.source_files  = "ios/**/*.{h,m,mm}"
 
-  s.dependency "React-Core"
-
   s.ios.weak_framework = 'LinkPresentation'
 
-  if ENV["RCT_NEW_ARCH_ENABLED"] == "1"
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-      "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-      "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-    }
-
-    s.dependency "React-Codegen"
-    s.dependency "React-RCTFabric"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
+  if defined?(install_modules_dependencies()) != nil
+    install_modules_dependencies(s)
+  else
+    s.dependency "React-Core"
   end
 
 end


### PR DESCRIPTION
## PR concerning New Architecture support in the library :tada:

We at [Software Mansion](https://swmansion.com/) have been working on [improving support](https://blog.swmansion.com/sunrising-new-architecture-in-the-new-expensify-app-729d237a02f5) for the new architecture for quite a while now. If you need help with anything related to New Architecture, like:
- [migrating your library](https://x.com/swmansion/status/1717512089323864275)
- [migrating your app](https://github.com/Expensify/App/pull/13767)
- [investigating issues](https://github.com/facebook/react-native/pulls?q=sort%3Aupdated-desc+is%3Apr+author%3Aj-piasecki+is%3Aopen)
- [improving performance](https://x.com/BBloniarz_/status/1808138585528303977)

or you just want to ask any questions, hit us up on [projects@swmansion.com](mailto:projects@swmansion.com)

---

### Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

PR adding proper way of adding dependencies on both new and old arch. See e.g. https://github.com/lottie-react-native/lottie-react-native/pull/1139 for similar change.

### Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Build project on old/new arch and see that everything works correctly.
