### PR TITLE
Updated deprecated  [[UIApplication sharedApplication] openURL]] for iOS 18 & Xcode 16

### DIFF
--- a/ios/FacebookStories.m
+++ b/ios/FacebookStories.m
@@ -87,7 +87,7 @@ RCT_EXPORT_MODULE();
     // Cannot open facebook
     NSString *stringURL = @"https://itunes.apple.com/app/facebook/id284882215";
     NSURL *url = [NSURL URLWithString:stringURL];
-    [[UIApplication sharedApplication] openURL:url];
+    [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
 
     NSString *errorMessage = @"Not installed";
     NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};

--- a/ios/GooglePlusShare.m
+++ b/ios/GooglePlusShare.m
@@ -21,7 +21,7 @@
         NSURL *gplusURL = [NSURL URLWithString:[url stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
 
         if ([[UIApplication sharedApplication] canOpenURL: gplusURL]) {
-            [[UIApplication sharedApplication] openURL:gplusURL];
+            [[UIApplication sharedApplication] openURL:gplusURL options:@{} completionHandler:nil];
             resolve(@[@true, @""]);
         } else {
             // Cannot open gplus

--- a/ios/InstagramShare.m
+++ b/ios/InstagramShare.m
@@ -44,7 +44,7 @@
     }
     
     if ([[UIApplication sharedApplication] canOpenURL: shareURL]) {
-        [[UIApplication sharedApplication] openURL: shareURL];
+        [[UIApplication sharedApplication] openURL:shareURL options:@{} completionHandler:nil];
         resolve(@[@true, @""]);
     } else {
         // Cannot open instagram
@@ -84,7 +84,7 @@
                               resolve: resolve];
         }
     } else {
-        [[UIApplication sharedApplication] openURL: [NSURL URLWithString:@"instagram://camera"]];
+        [[UIApplication sharedApplication] openURL: [NSURL URLWithString:@"instagram://camera"] options:@{} completionHandler:nil];
         resolve(@[@true, @""]);
     }
 }

--- a/ios/InstagramStories.m
+++ b/ios/InstagramStories.m
@@ -84,7 +84,7 @@ RCT_EXPORT_MODULE();
     // Cannot open instagram
     NSString *stringURL = @"https://itunes.apple.com/app/instagram/id389801252";
     NSURL *url = [NSURL URLWithString:stringURL];
-    [[UIApplication sharedApplication] openURL:url];
+    [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
 
     NSString *errorMessage = @"Not installed";
     NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};

--- a/ios/WhatsAppShare.m
+++ b/ios/WhatsAppShare.m
@@ -107,7 +107,7 @@ resolve:(RCTPromiseResolveBlock)resolve {
   NSURL * whatsappURL = [NSURL URLWithString:urlWhats];
   
   if ([[UIApplication sharedApplication] canOpenURL: whatsappURL]) {
-      [[UIApplication sharedApplication] openURL: whatsappURL];
+      [[UIApplication sharedApplication] openURL:whatsappURL options:@{} completionHandler:nil];
       resolve(@[@true, @""]);
   }
 }
@@ -144,7 +144,7 @@ resolve:(RCTPromiseResolveBlock)resolve {
       // Cannot open whatsapp
       NSString *appStoreStringURL = @"https://itunes.apple.com/app/whatsapp-messenger/id310633997";
       NSURL *appStoreURL = [NSURL URLWithString:appStoreStringURL];
-      [[UIApplication sharedApplication] openURL:appStoreURL];
+      [[UIApplication sharedApplication] openURL:appStoreURL options:@{} completionHandler:nil];
       return false;
   }
 }


### PR DESCRIPTION
**Bug** :-  WhatsApp share not working on iOS 18 while using Xcode 16.

**Reason** :-  [[UIApplication sharedApplication] openURL]] does not work on iOS 18 if built via Xcode 16

**Fix** :- Replacing the above with [[UIApplication sharedApplication] openURL: options: completionHandler:] fixed the issue

# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
