### PR TITLE
feat: Add support for Instagram Stories linkUrl/linkText

### DIFF
--- a/android/src/main/java/cl/json/social/InstagramStoriesShare.java
+++ b/android/src/main/java/cl/json/social/InstagramStoriesShare.java
@@ -83,6 +83,14 @@ public class InstagramStoriesShare extends SingleShareIntent {
             useInternalStorage = options.getBoolean("useInternalStorage");
         }
 
+        if (this.hasValidKey("linkUrl", options)) {
+            this.intent.putExtra("link_url", options.getString("linkUrl"));
+        }
+
+        if (this.hasValidKey("linkText", options)) {
+            this.intent.putExtra("link_text", options.getString("linkText"));
+        }
+
         Boolean hasBackgroundAsset = this.hasValidKey("backgroundImage", options)
                 || this.hasValidKey("backgroundVideo", options);
 

--- a/ios/InstagramStories.m
+++ b/ios/InstagramStories.m
@@ -67,6 +67,16 @@ RCT_EXPORT_MODULE();
     }
     [items setObject: backgroundBottomColor forKey: @"com.instagram.sharedSticker.backgroundBottomColor"];
 
+    if(![options[@"linkUrl"] isEqual:[NSNull null]] && options[@"linkUrl"] != nil) {
+        NSString *linkURL = [RCTConvert NSString:options[@"linkUrl"]];
+        [items setObject: linkURL forKey: @"com.instagram.sharedSticker.linkURL"];
+    }
+
+    if(![options[@"linkText"] isEqual:[NSNull null]] && options[@"linkText"] != nil) {
+        NSString *linkText = [RCTConvert NSString:options[@"linkText"]];
+        [items setObject: linkText forKey: @"com.instagram.sharedSticker.linkText"];
+    }
+
     // Putting dictionary of options inside an array
     NSArray *pasteboardItems = @[items];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,8 @@ interface BaseSocialStoriesShareSingleOptions extends Omit<BaseShareSingleOption
   backgroundTopColor?: string;
   attributionURL?: string;
   backgroundVideo?: string;
+  linkUrl?: string;
+  linkTitle?: string;
 }
 
 export interface InstagramStoriesShareSingleOptions extends BaseSocialStoriesShareSingleOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,7 +73,7 @@ interface BaseSocialStoriesShareSingleOptions extends Omit<BaseShareSingleOption
   attributionURL?: string;
   backgroundVideo?: string;
   linkUrl?: string;
-  linkTitle?: string;
+  linkText?: string;
 }
 
 export interface InstagramStoriesShareSingleOptions extends BaseSocialStoriesShareSingleOptions {

--- a/website/docs/share-single.mdx
+++ b/website/docs/share-single.mdx
@@ -127,6 +127,8 @@ Share.shareSingle(shareOptions);
 | backgroundTopColor | string   | default #906df4 | ✅
 | attributionURL | string   | (optional) facebook beta-test | ✅
 | backgroundVideo | string   | URL you want to share | ✅
+| linkUrl            | string   | (optional) A URL to be used as a link in the shared content. |                                                                                                   | ✅       | ✅      | ✅  | ❓      |
+| linkText           | string   | (optional) Text to be used as a link in the shared content. |                                                                                                     | ✅       | ✅      | ✅  | ❓      |
 
 ### Share image to Instagram
 


### PR DESCRIPTION
Related to #1590

# Overview
This PR adds support for the linkUrl/link Instagram Stories attributes. Instagram introduced new changes that rendered empty links for many. This PR allows you to set the link/text.

Kudos to @maxbb for the fix! 

| Before | After |
|-|-|
| ![Schermafbeelding 2024-10-25 om 09 54 27](https://github.com/user-attachments/assets/8c96a132-bc8f-408d-b8f8-6904a2592f21) | ![Schermafbeelding 2024-10-25 om 09 56 48](https://github.com/user-attachments/assets/c6f67024-e9b2-45fe-a827-bf0f67589d18) | 

Passing nothing (or an empty string for link/text) still renders the empty link.

# Test Plan
1. Apply this PR 
2. Make some code that shares something to Instagram Stories:

```ts
 await Share.shareSingle({
                    stickerImage: dataURI,
                    social: app.scheme,
                    appId: 'xxxx',
                    backgroundBottomColor: '#fefefe',
                    backgroundTopColor: '#906df4',
                    linkUrl: 'https://www.endgame.now/',
                    linkText: t`Download this app`,
                });
```

I was not able to test this on Android as I don't have a testing env with Instagram app set up.