### PR TITLE
Fix: fix large file sharing to instagram stories

### DIFF
--- a/ios/InstagramStories.m
+++ b/ios/InstagramStories.m
@@ -8,11 +8,23 @@
 
 // import RCTLog
 #import <React/RCTLog.h>
+#import <Photos/Photos.h>
 
 #import "InstagramStories.h"
 
 @implementation InstagramStories
 RCT_EXPORT_MODULE();
+
+- (void)openInstagramWithItems:(NSDictionary *)items urlScheme:(NSURL *)urlScheme resolve:(RCTPromiseResolveBlock)resolve {
+    // Putting dictionary of options inside an array
+    NSArray *pasteboardItems = @[items];
+    NSDictionary *pasteboardOptions = @{UIPasteboardOptionExpirationDate : [[NSDate date] dateByAddingTimeInterval:60 * 5]};
+    
+    [[UIPasteboard generalPasteboard] setItems:pasteboardItems options:pasteboardOptions];
+    [[UIApplication sharedApplication] openURL:urlScheme options:@{} completionHandler:nil];
+    
+    resolve(@[@true, @""]);
+}
 
 - (void)shareSingle:(NSDictionary *)options
     reject:(RCTPromiseRejectBlock)reject
@@ -40,12 +52,6 @@ RCT_EXPORT_MODULE();
         [items setObject: UIImagePNGRepresentation(image) forKey: @"com.instagram.sharedSticker.stickerImage"];
     }
 
-    if(![options[@"backgroundVideo"] isEqual:[NSNull null]] && options[@"backgroundVideo"] != nil) {
-        NSURL *backgroundVideoURL = [RCTConvert NSURL:options[@"backgroundVideo"]];
-        NSData *video = [NSData dataWithContentsOfURL:backgroundVideoURL];
-        [items setObject: video forKey: @"com.instagram.sharedSticker.backgroundVideo"];
-    }
-
     if(![options[@"attributionURL"] isEqual:[NSNull null]] && options[@"attributionURL"] != nil) {
         NSString *attrURL = [RCTConvert NSString:options[@"attributionURL"]];
         [items setObject: attrURL forKey: @"com.instagram.sharedSticker.contentURL"];
@@ -66,18 +72,57 @@ RCT_EXPORT_MODULE();
         backgroundBottomColor = @"#837DF4";
     }
     [items setObject: backgroundBottomColor forKey: @"com.instagram.sharedSticker.backgroundBottomColor"];
+    
+    if(![options[@"backgroundVideo"] isEqual:[NSNull null]] && options[@"backgroundVideo"] != nil) {
+        NSURL *backgroundVideoURL = [RCTConvert NSURL:options[@"backgroundVideo"]];
+        NSString *urlString = backgroundVideoURL.absoluteString;
+        NSURLComponents *components = [[NSURLComponents alloc] initWithString:urlString];
+        NSString *assetId = nil;
 
-    // Putting dictionary of options inside an array
-    NSArray *pasteboardItems = @[items];
+        // Get asset ID from URL
+        for (NSURLQueryItem *item in components.queryItems) {
+           if ([item.name isEqualToString:@"id"]) {
+               assetId = item.value;
+               break;
+           }
+        }
 
-    // Prepare options to instagram
-    NSDictionary *pasteboardOptions = @{UIPasteboardOptionExpirationDate : [[NSDate date] dateByAddingTimeInterval:60 * 5]};
-
-    // This call is iOS 10+, can use 'setItems' depending on what versions you support
-    [[UIPasteboard generalPasteboard] setItems:pasteboardItems options:pasteboardOptions];
-    [[UIApplication sharedApplication] openURL:urlScheme options:@{} completionHandler:nil];
-
-    resolve(@[@true, @""]);
+        if (assetId) {
+           // Fetch the asset
+           PHFetchResult *fetchResult = [PHAsset fetchAssetsWithLocalIdentifiers:@[assetId] options:nil];
+           PHAsset *asset = fetchResult.firstObject;
+           
+           if (asset) {
+               PHVideoRequestOptions *options = [[PHVideoRequestOptions alloc] init];
+               options.networkAccessAllowed = YES;
+               options.deliveryMode = PHVideoRequestOptionsDeliveryModeHighQualityFormat;
+               
+               [[PHImageManager defaultManager] requestAVAssetForVideo:asset
+                                                             options:options
+                                                       resultHandler:^(AVAsset * _Nullable avAsset, AVAudioMix * _Nullable audioMix, NSDictionary * _Nullable info) {
+                   if ([avAsset isKindOfClass:[AVURLAsset class]]) {
+                       AVURLAsset *urlAsset = (AVURLAsset *)avAsset;
+                       NSData *video = [NSData dataWithContentsOfURL:urlAsset.URL];
+                       
+                       dispatch_async(dispatch_get_main_queue(), ^{
+                           if (video) {
+                               [items setObject:video forKey:@"com.instagram.sharedSticker.backgroundVideo"];
+                               [self openInstagramWithItems:items urlScheme:urlScheme resolve:resolve];
+                           } else {
+                               NSLog(@"Failed to convert video asset to NSData");
+                               [self openInstagramWithItems:items urlScheme:urlScheme resolve:resolve];
+                           }
+                       });
+                   }
+               }];
+           } else {
+               NSLog(@"Could not find asset with ID: %@", assetId);
+               [self openInstagramWithItems:items urlScheme:urlScheme resolve:resolve];
+           }
+        }
+    } else {
+        [self openInstagramWithItems:items urlScheme:urlScheme resolve:resolve];
+    }
 }
 
 - (NSError*)fallbackInstagram {


### PR DESCRIPTION

# Overview
I am using this library on project that integrate social media accounts and their functionalitites such as sharing content and I encountered an issues when sharing to instagram story. After investigating the issues I found that there is an issue from the library side and after fixing it locally I wanted to contribute to the community so that I can help others out.


# Test Plan
The issue came from this line of code: 
`NSData *video = [NSData dataWithContentsOfURL:backgroundVideoURL];`
It returned nil and the story had no video displayed when it opened the instagram app.

I just modified the code to use PHAsset for retrieving the video data with the provided file_url in an asynchronous way so that larger files can also be supported.
I tested the code using an iOS device, given that the simulators do not support the installation of Instagram.
