### PR TITLE
New Feature: add base64 image support under linkMetadata for IOS for custom sharing icon

### DIFF
--- a/website/docs/share-open.mdx
+++ b/website/docs/share-open.mdx
@@ -133,6 +133,23 @@ const options = Platform.select({
           icon: icon,
         },
       },
+      {
+        // For using custom icon using Base64 image data instead of default text icon.
+        placeholderItem: {
+          type: 'url',
+          content: icon,
+        },
+        item: {
+          default: {
+            type: 'text',
+            content: `${message} ${url}`,
+          },
+        },
+        linkMetadata: {
+          title: message,
+          base64Icon: icon,
+        },
+      },
     ],
   },
   default: {
@@ -197,6 +214,7 @@ Also you can use `default` in order to specify default behavior.
 | image          | string | (optional) A URL of the file corresponding to a representative image for the URL.        |
 | remoteVideoUrl | string | (optional) A remote URL corresponding to a representative video for the URL.             |
 | video          | string | (optional) A URL of the file corresponding to a representative video for the URL.        |
+| base64Icon     | string | (optional) To display icon using Base64 image data.                                      |
 
 ## LSApplicationQueriesSchemes (iOS only)
 


### PR DESCRIPTION
# Overview

Enhancement to library [react-native-share](https://github.com/react-native-share/react-native-share) to load share icon image from base64.

require usage of changeOption to this format:

```
const shareOptions = Platform.select({
                ios: {
                    activityItemSources: [
                        {
                            placeholderItem: {
                                type: 'text',
                                content: '...'
                            },
                            item: {
                                type: 'text',
                                content: '...'
                            },
                            linkMetadata: {
                                title: 'Title M2U Receipt',
                                base64Icon: `${yourLogo}` <-- Note: pass base64 image data here, image can be converted to base64 and define directly in file. Instead of live conversion.
                            }
                        },
                    ],
                },
                default: {
                    title: 'Receipt',
                },
            });
```

![67990724-f8a2-435f-8537-a033e1f517bd](https://github.com/user-attachments/assets/aed59da0-7fc8-4997-ab51-778be4e7ced3)

