### PR TITLE
fix(types): add base64Icon to LinkMetadata interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export interface LinkMetadata {
   image?: string;
   remoteVideoUrl?: string;
   video?: string;
+  base64Icon?: string;
 }
 
 export interface ActivityItem {


### PR DESCRIPTION
# Overview
This adds `base64Icon` to the `LinkMetadata` interface, as per the [docs](https://react-native-share.github.io/react-native-share/docs/share-open#linkmetadata)

# Test Plan
N/A
