### PR TITLE
fix: use expo-build-properties to create the config plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Configure you `app.config.ts` or `app.json` to use the permissions needed by the
           "com.instagram.android",
           "com.twitter.android",
           "com.zhiliaoapp.musically",
-        ]
+        ],
+        "enableBase64ShareAndroid": true
       }
     ]
   ]
@@ -61,6 +62,12 @@ Configure you `app.config.ts` or `app.json` to use the permissions needed by the
   <package android:name="com.twitter.android" />
   <package android:name="com.zhiliaoapp.musically" />
 </queries>
+```
+
+`enableBase64ShareAndroid` will take care of adding the permission to the AndroidManifest.xml.
+
+```xml
+<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 ```
 
 And prebuild the project with `expo prebuild`.

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "babel-jest": "^29.7.0",
     "eslint": "^8.53.0",
     "eslint-config-satya164": "^3.2.0",
+    "expo-build-properties": "^0.13.1",
     "husky": "^4.3.0",
     "jest": "^29.7.0",
     "lint-staged": "^15.0.2",

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -1,93 +1,45 @@
-import {
-  withAndroidManifest,
-  createRunOncePlugin,
-  ExportedConfigWithProps,
-  ExportedConfig,
-} from '@expo/config-plugins';
+import { ExportedConfig } from '@expo/config-plugins';
+import { withBuildProperties } from 'expo-build-properties';
 
-// eslint-disable-next-line import/no-commonjs, @typescript-eslint/no-var-requires
-const pkg = require('../../package.json');
-
-/**
- * @type {import('./types').ManifestQueries}
- * what we are trying to add:
- * <queries>
-    <package android:name="com.facebook.katana"/>
-    <package android:name="com.instagram.android"/>
-    <package android:name="com.twitter.android"/>
-    <package android:name="com.zhiliaoapp.musically"/>
-    <intent></intent>
-      <action android:name="android.intent.action.VIEW"/>
-      <category android:name="android.intent.category.BROWSABLE"/>
-      <data android:scheme="https"/>
-    </intent>
-  </queries>
- */
-
-/**
- * @param {import('@expo/config-plugins').ExportedConfig} config
- */
-const withAndroidManifestService = (config: ExportedConfig, props: WithSocialShareProps) => {
-  return withAndroidManifest(config, (config: ExportedConfigWithProps) => {
-    config.modResults.manifest = {
-      ...config.modResults.manifest,
-      queries: {
-        package: props?.android?.map((social) => ({
-          $: {
-            'android:name': social,
-          },
-        })),
-        intent: [
-          {
-            action: {
-              $: {
-                'android:name': 'android.intent.action.VIEW',
-              },
-            },
-            category: {
-              $: {
-                'android:name': 'android.intent.category.BROWSABLE',
-              },
-            },
-            data: {
-              $: {
-                'android:scheme': 'https',
-              },
-            },
-          },
-        ],
+export default (
+  config: ExportedConfig,
+  props: {
+    enableBase64ShareAndroid?: boolean;
+    android?: string[];
+    ios?: string[];
+  },
+) => {
+  return withBuildProperties(
+    {
+      ...config,
+      android: {
+        ...config.android,
+        ...(props.enableBase64ShareAndroid
+          ? {
+              permissions: [
+                ...(config.android?.permissions ?? []),
+                'android.permission.WRITE_EXTERNAL_STORAGE',
+              ],
+            }
+          : {}),
       },
-    };
-
-    return config;
-  });
-};
-
-const withInfoPlist = (config: ExportedConfig, props: WithSocialShareProps) => {
-  return {
-    ...config,
-    ios: {
-      ...config.ios,
-      infoPlist: {
-        ...config.ios?.infoPlist,
-        LSApplicationQueriesSchemes: config.ios?.infoPlist?.LSApplicationQueriesSchemes
-          ? [...config.ios.infoPlist.LSApplicationQueriesSchemes, ...props.ios]
-          : props.ios,
+      ios: {
+        ...config.ios,
+        infoPlist: {
+          ...config.ios?.infoPlist,
+          LSApplicationQueriesSchemes: [
+            ...(config.ios?.infoPlist?.LSApplicationQueriesSchemes ?? []),
+            ...(props.ios ?? []),
+          ],
+        },
       },
     },
-  };
+    {
+      android: {
+        manifestQueries: {
+          package: props.android ?? [],
+        },
+      },
+    },
+  );
 };
-
-type WithSocialShareProps = {
-  ios: string[];
-  android: string[];
-};
-
-function withSocialShare(config: ExportedConfig, props: WithSocialShareProps) {
-  config = withAndroidManifestService(config, props); // Android
-  config = withInfoPlist(config, props); // iOS
-  return config;
-}
-
-// eslint-disable-next-line import/no-commonjs
-module.exports = createRunOncePlugin(withSocialShare, pkg.name, pkg.version);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3206,6 +3206,16 @@ ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ajv@^8.11.0:
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
+  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+
 anser@^1.4.9:
   version "1.4.10"
   resolved "https://registry.yarnpkg.com/anser/-/anser-1.4.10.tgz#befa3eddf282684bd03b63dcda3927aef8c2e35b"
@@ -5278,6 +5288,14 @@ expect@^29.7.0:
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
 
+expo-build-properties@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/expo-build-properties/-/expo-build-properties-0.13.1.tgz#e40645b34debed5eab53a273c89543aaef58bc57"
+  integrity sha512-7tDlAM0PPkXC0B00C6/FG19sMzwxZNyiDfn22AWVbBxWxZE1/3RqxPgT3MlPVNfvy+wJw7jt/qbAb0S06wFYVg==
+  dependencies:
+    ajv "^8.11.0"
+    semver "^7.6.0"
+
 exponential-backoff@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.1.tgz#64ac7526fe341ab18a39016cd22c787d01e00bf6"
@@ -5313,6 +5331,11 @@ fast-levenshtein@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
+
+fast-uri@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.0.3.tgz#892a1c91802d5d7860de728f18608a0573142241"
+  integrity sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==
 
 fast-xml-parser@^4.0.12:
   version "4.3.2"
@@ -7214,6 +7237,11 @@ json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
@@ -9920,6 +9948,11 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
 require-in-the-middle@^7.1.1:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/require-in-the-middle/-/require-in-the-middle-7.2.0.tgz#b539de8f00955444dc8aed95e17c69b0a4f10fcf"
@@ -10183,6 +10216,11 @@ semver@^7.0.0, semver@^7.1.1, semver@^7.1.2, semver@^7.3.2, semver@^7.3.4, semve
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^7.6.0:
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
+  integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
 
 send@0.19.0:
   version "0.19.0"
@@ -10655,7 +10693,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10668,6 +10706,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -11408,7 +11453,16 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@7.0.0, wrap-ansi@^6.2.0, wrap-ansi@^7.0.0, wrap-ansi@^8.0.1, wrap-ansi@^8.1.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@7.0.0, wrap-ansi@^6.2.0, wrap-ansi@^7.0.0, wrap-ansi@^8.0.1, wrap-ansi@^8.1.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
Instead of manually recreating everything, I've just used expo-build-properties.

This fixes that plugin so that it does not override other manifest queries from other plugins but gracefully merges everything.

# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
