### PR TITLE
fix(ios): handle for edge case in Expo plugin when LSApplicationQueriesSchemes is an object and props are undefined

### DIFF
--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -63,6 +63,15 @@ const withAndroidManifestService = (config: ExportedConfig, props: WithSocialSha
   });
 };
 
+/**
+* Handles for edge case when LSApplicationQueriesSchemes is an object or undefined.
+*/
+const getIOSQuerySchemes = (config: ExportedConfig): Array<string> => {
+  return Array.isArray(config.ios?.infoPlist?.LSApplicationQueriesSchemes)
+    ? config.ios.infoPlist.LSApplicationQueriesSchemes
+    : [];
+}
+
 const withInfoPlist = (config: ExportedConfig, props: WithSocialShareProps) => {
   return {
     ...config,
@@ -70,9 +79,7 @@ const withInfoPlist = (config: ExportedConfig, props: WithSocialShareProps) => {
       ...config.ios,
       infoPlist: {
         ...config.ios?.infoPlist,
-        LSApplicationQueriesSchemes: config.ios?.infoPlist?.LSApplicationQueriesSchemes
-          ? [...config.ios.infoPlist.LSApplicationQueriesSchemes, ...props.ios]
-          : props.ios,
+        LSApplicationQueriesSchemes: [...getIOSQuerySchemes(config), ...props?.ios ?? []]
       },
     },
   };

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -68,7 +68,7 @@ const withAndroidManifestService = (config: ExportedConfig, props: WithSocialSha
 */
 const getIOSQuerySchemes = (config: ExportedConfig): Array<string> => {
   return Array.isArray(config.ios?.infoPlist?.LSApplicationQueriesSchemes)
-    ? config.ios.infoPlist.LSApplicationQueriesSchemes
+    ? config?.ios.infoPlist?.LSApplicationQueriesSchemes ?? []
     : [];
 }
 

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -68,7 +68,7 @@ const withAndroidManifestService = (config: ExportedConfig, props: WithSocialSha
 */
 const getIOSQuerySchemes = (config: ExportedConfig): Array<string> => {
   return Array.isArray(config.ios?.infoPlist?.LSApplicationQueriesSchemes)
-    ? config?.ios.infoPlist?.LSApplicationQueriesSchemes ?? []
+    ? config.ios?.infoPlist?.LSApplicationQueriesSchemes ?? []
     : [];
 }
 


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
I ran into two edge cases when trying to utilize this package, specifically when using the Expo plugin. First, when running `expo prebuild` within my real project, I received an error `Cannot read properties of undefined (reading 'ios')`.

<img width="1234" alt="Screenshot 2024-12-29 at 2 55 45 PM" src="https://github.com/user-attachments/assets/702ac16e-4d58-42c8-a88d-ed8dd12e1455" />

Upon investigation, the error appeared to be occurring because the `props` parameter was undefined.

To further diagnose I created a minimal repo, only to run into another error upon prebuild, `TypeError: config.ios.infoPlist.LSApplicationQueriesSchemes is not iterable`.

<img width="1217" alt="Screenshot 2024-12-29 at 2 55 26 PM" src="https://github.com/user-attachments/assets/9874b3ab-0f9f-411b-a6c6-a52353c23e0c" />

I added some logging just inside my node_modules folder and discovered that LSApplicationQueriesSchemes was being provided as an object in my case (I'm not sure why this is occurring exactly, it's listed as an array within the Info.plist file).

To fix this, I added a function which checks whether the Query Schemes are an array as expected and if they are not returns an empty array. I also added a fallback for `props.ios` in case the props parameter is undefined as in my case.

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
After updating the code, I replaced my existing code within my node_modules folders in both packages, and the prebuild process executed as expected. These tests cover scenarios where:

* LSApplicationQuerySchemes is undefined
* LSApplicationQuerySchemes is an array of strings but props was undefined
* LSApplicationQuerySchemes is an object

which from what I can tell covers all preexisting scenarios, plus the new edge cases I discovered.

- Fixes #1623 