### PR TITLE
fix: handle RN 0.77 breaking change for event listener unsubscribe

### DIFF
--- a/src/components/ShareSheet.tsx
+++ b/src/components/ShareSheet.tsx
@@ -34,9 +34,9 @@ const ShareSheet: React.FC<React.PropsWithChildren<ShareSheetProps>> = ({
   }, [visible, onCancel]);
 
   React.useEffect(() => {
-    BackHandler.addEventListener('hardwareBackPress', backButtonHandler);
+    const subscription = BackHandler.addEventListener('hardwareBackPress', backButtonHandler);
     return () => {
-      BackHandler.removeEventListener('hardwareBackPress', backButtonHandler);
+      subscription.remove();
     };
   }, [backButtonHandler]);
 


### PR DESCRIPTION
# Overview
Since RN 0.77 removeEventListener no longer exists on BackHandler, causing type errors. Updated ShareSheet to use new method of removing the subscription. More information can be found here: https://reactnative.dev/blog/2025/01/21/version-0.77#android

![image](https://github.com/user-attachments/assets/8df3e58b-0ed5-4eba-bb5b-549a06930efa)

# Test Plan
Verified within my own production app that it now builds and doesn't cause type errors