### PR TITLE
fix(ios): update shareSingle method to check if inAppBaseUrl can be opened instead of checking only for Twitter

### DIFF
--- a/ios/GenericShare.m
+++ b/ios/GenericShare.m
@@ -17,7 +17,7 @@
     inAppBaseUrl:(NSString *)inAppBaseUrl {
 
     NSLog(@"Try open view");
-    if([serviceType isEqualToString:@"com.apple.social.twitter"]) {
+    if([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:inAppBaseUrl]]) {
         SLComposeViewController *composeController = [SLComposeViewController  composeViewControllerForServiceType:serviceType];
 
         NSURL *URL = [RCTConvert NSURL:options[@"url"]];


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Sharing to Facebook is not supported on iOS and will always open a web browser.

Check: https://github.com/react-native-share/react-native-share/issues/1657, https://github.com/react-native-share/react-native-share/issues/1535, and https://github.com/react-native-share/react-native-share/pull/1315#issuecomment-1548745717.

Looking at the code, sharing on Facebook uses the [GenericShare](https://github.com/react-native-share/react-native-share/blob/main/ios/GenericShare.m) on iOS, which always throws an error and opens a web browser as it [only supports Twitter](https://github.com/react-native-share/react-native-share/pull/1315).

Instead, we should show the share sheet for any app if the provided URL can be opened, or at least be explicit about the apps we support ([Twitter](https://github.com/react-native-share/react-native-share/blob/a8f5fc4094b511b233d45a978d08665a39da42ad/ios/RNShare.mm#L134) and [Facebook](https://github.com/react-native-share/react-native-share/blob/a8f5fc4094b511b233d45a978d08665a39da42ad/ios/RNShare.mm#L120))


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

- Check if sharing on Facebook and Twitter works as expected on iOS.

### Twitter:

<img src="https://github.com/user-attachments/assets/3c530fb6-10aa-495c-a8ef-688d12c1e810" alt="drawing" width="300"/>


### Facebook:

<img src="https://github.com/user-attachments/assets/e63094eb-41c6-49b8-8657-ebcc6946da2e" alt="drawing" width="300"/>



