### PR TITLE
feat: add ability to disable iOS overlay on bare share activity

### DIFF
--- a/ios/RNShare.mm
+++ b/ios/RNShare.mm
@@ -290,10 +290,18 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options
             [controller presentViewController:documentPicker animated:YES completion:nil];
             return;
         }
-    }
-
+    }    
+    
     UIActivityViewController *shareController = [[UIActivityViewController alloc] initWithActivityItems:items applicationActivities:nil];
 
+    BOOL disableOverlay = [RCTConvert BOOL:options[@"disableOverlay"]];
+    
+    if (@available(iOS 15.0, *)) {
+        if (disableOverlay == true) {
+                shareController.sheetPresentationController.largestUndimmedDetentIdentifier = UISheetPresentationControllerDetentIdentifierLarge;
+        }
+    }
+    
     NSString *subject = [RCTConvert NSString:options[@"subject"]];
     if (subject) {
         [shareController setValue:subject forKey:@"subject"];

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,6 +109,8 @@ export interface ShareOptions {
   saveToFiles?: boolean;
   activityItemSources?: ActivityItemSource[];
   isNewTask?: boolean;
+  /** iOS Only */
+  disableOverlay?: boolean;
 }
 
 export type ActivityType =

--- a/website/docs/share-open.mdx
+++ b/website/docs/share-open.mdx
@@ -52,6 +52,7 @@ You can customize the call to `Share.open` passing the following parameters:
 | activityItemSources   | Array[Object] | Array of activity item sources. Each items should conform to [ActivityItemSource](#activityitemsource) specification. [Example](#example-activityitemsources). | ✅       | 🚫      | ✅  | ❓      |
 | useInternalStorage    |    boolean    | Store the temporary file in the internal storage cache (Android only)                                                                                          | ✅       | ✅      | 🚫  | 🚫      |
 | isNewTask             |    boolean    | Open intent as a new task. "failOnCancel" will not work.                                                                                                       | ✅       | ✅      | 🚫  | ❓      |
+| disableOverlay        |    boolean    | Disable dimming/dismissible overlay of share activity                                                                                                          | ✅       | 🚫      | ✅  | ❓      |
 
 ## Sharing a base64 file format
 


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

I noticed that RetroApp has a pretty cool feature that renders a custom preview for shared images.
I figured out how to achieve the same and thought it’d be great to share this little feature with the React Native community. Since I use this package every day, I’d love to contribute it here!

# Demo

https://github.com/user-attachments/assets/1b52c00e-333c-42fd-ad92-49946648ea66

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
<!-- Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Sadly I haven't found a way to disable it on Android but below recorded that it's not breaking anything

| iOS | Android | 
| --- | --- |
| <video src="https://github.com/user-attachments/assets/65b12755-4a18-42d0-9aab-aaf2fa463f9f"> |  <video src="https://github.com/user-attachments/assets/f69abb93-bec1-41b4-937d-4e87597f6d38"> | 