### PR TITLE
Fix root path security issue

### DIFF
--- a/android/src/main/res/xml/share_download_paths.xml
+++ b/android/src/main/res/xml/share_download_paths.xml
@@ -2,5 +2,4 @@
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <external-path name="rnshare1" path="Download/" />
     <cache-path name="rnshare2" path="/" />
-    <root-path name="rnshare_sdcard" path="." />
 </paths>


### PR DESCRIPTION
## 🛡️ Overview

This PR removes the use of `<root-path>` from the `FileProvider` configuration. It was originally added in [PR #754](https://github.com/react-native-share/react-native-share/pull/754) to support SD card sharing, but it's considered unsafe and creates security issues for the apps using this library.

Using `<root-path path="."/>` exposes too much. Apps should explicitly define safer paths like `cache-path` or `files-path` to avoid unintentionally sharing sensitive data.

Per [Android docs](https://developer.android.com/privacy-and-security/risks/file-providers#do_not_use_the_root-path_path_element_in_the_configuration):

> `<root-path>` grants broad access to internal and external storage, increasing attack surface via `content://` URIs.




