### PR TITLE
fix: add internal files path to Android FileProvider

### DIFF
--- a/android/src/main/res/xml/share_download_paths.xml
+++ b/android/src/main/res/xml/share_download_paths.xml
@@ -2,4 +2,5 @@
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <external-path name="rnshare1" path="Download/" />
     <cache-path name="rnshare2" path="/" />
+    <files-path name="rnshare3" path="." />
 </paths>


### PR DESCRIPTION
# Overview

Closes #1764.

The Android FileProvider bundled with `react-native-share` currently exposes downloads and cache files, but it does not expose files from the app's internal files directory. When a user shares a `file://` URI that points under internal files, `FileProvider.getUriForFile(...)` cannot match it against the configured paths, so receiving apps may fail to access the shared image/file.

This adds a `<files-path>` entry to the bundled `share_download_paths.xml`, matching the workaround described in the issue while keeping the existing provider authority and cache/download paths unchanged.

# Test Plan

Commands and integration checks run locally:

- Parsed `android/src/main/res/xml/share_download_paths.xml` with Python's XML parser: passed
- `git diff --check`: passed
- Reproduced the integration path with Expo SDK 55 and React Native 0.83.6 after applying this PR's XML change to `react-native-share` 12.3.1
- Confirmed Expo prebuild does not copy the dependency Manifest or XML into `android/app/src`; this is expected because React Native autolinks the package as an Android library
- Ran Android Gradle Plugin 8.12 `:app:processDebugMainManifest :app:mergeDebugResources`: passed
- Confirmed the merged application Manifest contains `cl.json.RNShareFileProvider`, the resolved `<applicationId>.rnshare.fileprovider` authority, and `@xml/share_download_paths`
- Confirmed the packaged library resource contains `<files-path name="rnshare3" path="." />`

These checks validate the Manifest/resource integration discussed in the follow-up. Device-level sharing still needs confirmation in the reproduction app.
