### PR TITLE
fix(ios): report correct success value from shareSingle

### DIFF
--- a/ios/DiscordShare.m
+++ b/ios/DiscordShare.m
@@ -22,7 +22,7 @@
     
     if ([[UIApplication sharedApplication] canOpenURL: shareURL]) {
         [[UIApplication sharedApplication] openURL: shareURL];
-        resolve(@[@true, @""]);
+        resolve(@{@"success": @(YES), @"message": @""});
     } else {
         NSString *stringURL = @"https://apps.apple.com/us/app/discord-chat-talk-hangout/id985746746";
         NSURL *url = [NSURL URLWithString:stringURL];

--- a/ios/EmailShare.m
+++ b/ios/EmailShare.m
@@ -131,7 +131,7 @@
             // on the finish delegate.
             // For now, call it here for consistency with
             // GenericShare.shareSingle
-            resolve(@[@true, @""]);
+            resolve(@{@"success": @(YES), @"message": @""});
         });
     }
 }

--- a/ios/FacebookStories.m
+++ b/ios/FacebookStories.m
@@ -80,7 +80,7 @@ RCT_EXPORT_MODULE();
     [[UIPasteboard generalPasteboard] setItems:pasteboardItems options:pasteboardOptions];
     [[UIApplication sharedApplication] openURL:urlScheme options:@{} completionHandler:nil];
 
-    resolve(@[@true, @""]);
+    resolve(@{@"success": @(YES), @"message": @""});
 }
 
 - (NSError*)fallbackFacebook {

--- a/ios/GenericShare.m
+++ b/ios/GenericShare.m
@@ -47,7 +47,7 @@
 
         UIViewController *ctrl = RCTPresentedViewController();
         [ctrl presentViewController:composeController animated:YES completion:Nil];
-        resolve(@[@true, @""]);
+        resolve(@{@"success": @(YES), @"message": @""});
       } else {
         NSString *errorMessage = @"Not installed";
         NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};

--- a/ios/GooglePlusShare.m
+++ b/ios/GooglePlusShare.m
@@ -22,7 +22,7 @@
 
         if ([[UIApplication sharedApplication] canOpenURL: gplusURL]) {
             [[UIApplication sharedApplication] openURL:gplusURL options:@{} completionHandler:nil];
-            resolve(@[@true, @""]);
+            resolve(@{@"success": @(YES), @"message": @""});
         } else {
             // Cannot open gplus
             NSString *errorMessage = @"Not installed";

--- a/ios/InstagramShare.m
+++ b/ios/InstagramShare.m
@@ -45,7 +45,7 @@
 
     if ([[UIApplication sharedApplication] canOpenURL: shareURL]) {
         [[UIApplication sharedApplication] openURL:shareURL options:@{} completionHandler:nil];
-        resolve(@[@true, @""]);
+        resolve(@{@"success": @(YES), @"message": @""});
     } else {
         // Cannot open instagram
         NSString *stringURL = @"https://itunes.apple.com/app/instagram/id389801252";
@@ -85,7 +85,7 @@
         }
     } else {
         [[UIApplication sharedApplication] openURL: [NSURL URLWithString:@"instagram://camera"] options:@{} completionHandler:nil];
-        resolve(@[@true, @""]);
+        resolve(@{@"success": @(YES), @"message": @""});
     }
 }
 
@@ -136,7 +136,7 @@
                         [[UIApplication sharedApplication] openURL:instagramURL options:@{} completionHandler:NULL];
                     }
                     if (resolve != NULL) {
-                        resolve(@[@true, @""]);
+                        resolve(@{@"success": @(YES), @"message": @""});
                     }
                 }
             }

--- a/ios/InstagramStories.m
+++ b/ios/InstagramStories.m
@@ -23,7 +23,7 @@ RCT_EXPORT_MODULE();
     [[UIPasteboard generalPasteboard] setItems:pasteboardItems options:pasteboardOptions];
     [[UIApplication sharedApplication] openURL:urlScheme options:@{} completionHandler:nil];
 
-    resolve(@[@true, @""]);
+    resolve(@{@"success": @(YES), @"message": @""});
 }
 
 - (void)shareSingle:(NSDictionary *)options

--- a/ios/MessengerShare.m
+++ b/ios/MessengerShare.m
@@ -15,7 +15,7 @@ RCT_EXPORT_MODULE();
     if ([[UIApplication sharedApplication] canOpenURL:url]) {
       [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
 
-      resolve(@[@true, @""]);
+      resolve(@{@"success": @(YES), @"message": @""});
     } else {
       // Cannot open Messenger
       NSString *contentLinkString = @"https://apps.apple.com/us/app/messenger/id454638411";

--- a/ios/SmsShare.m
+++ b/ios/SmsShare.m
@@ -98,7 +98,7 @@
                 }
             } else {
                 if (self.resolve) {
-                    self.resolve(@[@(result == MessageComposeResultSent), @""]);
+                    self.resolve(@{@"success": @(result == MessageComposeResultSent), @"message": @""});
                 }
             }
             self.resolve = nil;

--- a/ios/TelegramShare.m
+++ b/ios/TelegramShare.m
@@ -28,7 +28,7 @@
     
     if ([[UIApplication sharedApplication] canOpenURL: shareURL]) {
         [[UIApplication sharedApplication] openURL: shareURL options:@{} completionHandler:nil];
-        resolve(@[@true, @""]);
+        resolve(@{@"success": @(YES), @"message": @""});
     } else {
         // Cannot open telegram
         NSString *stringURL = @"https://itunes.apple.com/app/telegram-messenger/id686449807";

--- a/ios/TwitterShare.m
+++ b/ios/TwitterShare.m
@@ -32,7 +32,7 @@ RCT_EXPORT_MODULE();
 
     if ([[UIApplication sharedApplication] canOpenURL:appUrl]) {
         [[UIApplication sharedApplication] openURL:appUrl options:@{} completionHandler:^(BOOL success) {}];
-        resolve(@[@true, @"opened in twitter app"]);
+        resolve(@{@"success": @(YES), @"message": @"opened in twitter app"});
     } else {
         // Fallback to web intent
         NSString *webUrlString = url ?
@@ -41,7 +41,7 @@ RCT_EXPORT_MODULE();
 
         NSURL *webUrl = [NSURL URLWithString:webUrlString];
         [[UIApplication sharedApplication] openURL:webUrl options:@{} completionHandler:^(BOOL success) {}];
-        resolve(@[@true, @"opened in browser"]);
+        resolve(@{@"success": @(YES), @"message": @"opened in browser"});
     }
 }
 

--- a/ios/ViberShare.m
+++ b/ios/ViberShare.m
@@ -26,7 +26,7 @@
     
     if ([[UIApplication sharedApplication] canOpenURL: shareURL]) {
         [[UIApplication sharedApplication] openURL: shareURL options:@{} completionHandler:nil];
-        resolve(@[@true, @""]);
+        resolve(@{@"success": @(YES), @"message": @""});
     } else {
         // Cannot open viber
         NSString *stringURL = @"https://apps.apple.com/app/viber-messenger-chats-calls/id382617920";

--- a/ios/WhatsAppShare.m
+++ b/ios/WhatsAppShare.m
@@ -79,7 +79,7 @@ resolve:(RCTPromiseResolveBlock)resolve {
       
         [self shareMedia:filePath documentUTI:@"net.whatsapp.image"];
       
-        resolve(@[@true, @""]);
+        resolve(@{@"success": @(YES), @"message": @""});
     }
 
   }else {
@@ -95,7 +95,7 @@ resolve:(RCTPromiseResolveBlock)resolve {
   NSLog(@"Sending whatsapp movie");
   [self shareMedia:options[@"url"] documentUTI:@"net.whatsapp.movie"];
   NSLog(@"Done whatsapp movie");
-  resolve(@[@true, @""]);
+  resolve(@{@"success": @(YES), @"message": @""});
 }
 
 - (void)tryToSendAudio:(NSDictionary *)options
@@ -105,7 +105,7 @@ resolve:(RCTPromiseResolveBlock)resolve {
   NSLog(@"Sending whatsapp audio");
   [self shareMedia:options[@"url"] documentUTI:@"net.whatsapp.audio"];
   NSLog(@"Done whatsapp audio");
-  resolve(@[ @true, @"" ]);
+  resolve(@{@"success": @(YES), @"message": @""});
 }
 
 -(void)tryToSendText:(NSDictionary *)options
@@ -125,7 +125,7 @@ resolve:(RCTPromiseResolveBlock)resolve {
   
   if ([[UIApplication sharedApplication] canOpenURL: whatsappURL]) {
       [[UIApplication sharedApplication] openURL:whatsappURL options:@{} completionHandler:nil];
-      resolve(@[@true, @""]);
+      resolve(@{@"success": @(YES), @"message": @""});
   }
 }
 


### PR DESCRIPTION
# Overview

`Share.shareSingle` reports `success: false` on iOS even when the share
succeeds. Reported in #1668, #1694 and #1555, and still reproducible on the
latest release (12.3.1).

The JS layer reads the native result as an object:

    const { success, message } = await NativeRNShare.shareSingle(options);

Android resolves that object and the type declares it
(`Promise<{ success: boolean; message: string }>`). But the iOS modules
resolved an array `[bool, ""]`, so `success` came back `undefined` and always
read as `false`.

This switches the iOS modules to resolve `{ success, message }`, the same shape
already used by `open()` in the same file and by Android. No public API change:
`shareSingle` already wraps the result into `{ success, message }` before
returning, so apps just get a correct `success` value now.

Affected targets: SMS, WhatsApp, Telegram, Instagram, Discord, Email, Twitter,
Viber, Messenger, Google+, generic, and Facebook/Instagram stories.

Fixes #1668

# Test Plan

- `yarn lint` and `yarn typescript` pass (no JS/TS changes).
- The iOS example app builds and launches with the change.
- To verify behavior: call `Share.shareSingle({ social })` and inspect the
  resolved value. Before, `success` reads `false` on iOS even on a successful
  share; after, it is the correct boolean with the expected `message`.
