### PR TITLE
fix: reduce bridge work and preserve public share contracts

### DIFF
--- a/src/helpers/android.ts
+++ b/src/helpers/android.ts
@@ -4,6 +4,9 @@ import NativeRNShare from '../codegenSpec/NativeRNShare';
 import { getAndroidVersion } from './platform';
 
 export async function checkAndroidPermissionsForUrls(urls: string[]) {
+  // App-specific external storage needs no permission on Android 4.4 and later.
+  if (getAndroidVersion() >= 19) return;
+
   // Reference: https://github.com/react-native-share/react-native-share/pull/871
   if ((await Promise.all(urls.map((url) => NativeRNShare.isBase64File(url)))).includes(true)) {
     await checkExternalStoragePermission();
@@ -16,15 +19,9 @@ async function checkExternalStoragePermission() {
   const granted = await PermissionsAndroid.check(WRITE_EXTERNAL_STORAGE);
 
   if (!granted) {
-    if (!isAndroidVersionAtLeastKitKat()) {
-      const result = await PermissionsAndroid.request(WRITE_EXTERNAL_STORAGE);
-      if (result !== PermissionsAndroid.RESULTS.GRANTED) {
-        throw new Error('Write Permission not available');
-      }
+    const result = await PermissionsAndroid.request(WRITE_EXTERNAL_STORAGE);
+    if (result !== PermissionsAndroid.RESULTS.GRANTED) {
+      throw new Error('Write Permission not available');
     }
   }
-}
-
-function isAndroidVersionAtLeastKitKat() {
-  return getAndroidVersion() >= 19;
 }

--- a/src/helpers/options.ts
+++ b/src/helpers/options.ts
@@ -21,6 +21,6 @@ export function normalizeShareOpenOptions({ ...options }: ShareOptions) {
 }
 
 export function normalizeSingleShareOptions({ ...options }: ShareSingleOptions) {
-  if (options.url) options.urls = [options.url];
+  if (options.url && !options.urls) options.urls = [options.url];
   return options;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,6 +18,8 @@ import {
 import { isAndroid, isIOS } from './helpers/platform';
 import { normalizeShareOpenOptions, normalizeSingleShareOptions } from './helpers/options';
 
+const constants = NativeRNShare.getConstants();
+
 const RNShare = {
   Button,
   ShareSheet,
@@ -25,24 +27,24 @@ const RNShare = {
   Sheet,
 
   Social: {
-    FACEBOOK: NativeRNShare.getConstants().FACEBOOK || Social.Facebook,
-    FACEBOOK_STORIES: NativeRNShare.getConstants().FACEBOOKSTORIES || Social.FacebookStories,
-    PAGESMANAGER: NativeRNShare.getConstants().PAGESMANAGER || Social.Pagesmanager,
-    TWITTER: NativeRNShare.getConstants().TWITTER || Social.Twitter,
-    WHATSAPP: NativeRNShare.getConstants().WHATSAPP || Social.Whatsapp,
-    WHATSAPPBUSINESS: NativeRNShare.getConstants().WHATSAPPBUSINESS || Social.Whatsappbusiness,
-    INSTAGRAM: NativeRNShare.getConstants().INSTAGRAM || Social.Instagram,
-    INSTAGRAM_STORIES: NativeRNShare.getConstants().INSTAGRAMSTORIES || Social.InstagramStories,
-    GOOGLEPLUS: NativeRNShare.getConstants().GOOGLEPLUS || Social.Googleplus,
-    EMAIL: NativeRNShare.getConstants().EMAIL || Social.Email,
-    PINTEREST: NativeRNShare.getConstants().PINTEREST || Social.Pinterest,
-    LINKEDIN: NativeRNShare.getConstants().LINKEDIN || Social.Linkedin,
-    SMS: NativeRNShare.getConstants().SMS || Social.Sms,
-    TELEGRAM: NativeRNShare.getConstants().TELEGRAM || Social.Telegram,
-    MESSENGER: NativeRNShare.getConstants().MESSENGER || Social.Messenger,
-    SNAPCHAT: NativeRNShare.getConstants().SNAPCHAT || Social.Snapchat,
-    VIBER: NativeRNShare.getConstants().VIBER || Social.Viber,
-    DISCORD: NativeRNShare.getConstants().DISCORD || Social.Discord,
+    FACEBOOK: constants.FACEBOOK || Social.Facebook,
+    FACEBOOK_STORIES: constants.FACEBOOKSTORIES || Social.FacebookStories,
+    PAGESMANAGER: constants.PAGESMANAGER || Social.Pagesmanager,
+    TWITTER: constants.TWITTER || Social.Twitter,
+    WHATSAPP: constants.WHATSAPP || Social.Whatsapp,
+    WHATSAPPBUSINESS: constants.WHATSAPPBUSINESS || Social.Whatsappbusiness,
+    INSTAGRAM: constants.INSTAGRAM || Social.Instagram,
+    INSTAGRAM_STORIES: constants.INSTAGRAMSTORIES || Social.InstagramStories,
+    GOOGLEPLUS: constants.GOOGLEPLUS || Social.Googleplus,
+    EMAIL: constants.EMAIL || Social.Email,
+    PINTEREST: constants.PINTEREST || Social.Pinterest,
+    LINKEDIN: constants.LINKEDIN || Social.Linkedin,
+    SMS: constants.SMS || Social.Sms,
+    TELEGRAM: constants.TELEGRAM || Social.Telegram,
+    MESSENGER: constants.MESSENGER || Social.Messenger,
+    SNAPCHAT: constants.SNAPCHAT || Social.Snapchat,
+    VIBER: constants.VIBER || Social.Viber,
+    DISCORD: constants.DISCORD || Social.Discord,
   },
 
   async open(options: ShareOptions) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,6 @@ import checkPermissions from './helpers/checkPermissions';
 import {
   Social,
   IsPackageInstalledResult,
-  ActivityType,
   ShareAsset,
   ShareOpenResult,
   ShareOptions,
@@ -27,24 +26,27 @@ const RNShare = {
   Sheet,
 
   Social: {
-    FACEBOOK: constants.FACEBOOK || Social.Facebook,
-    FACEBOOK_STORIES: constants.FACEBOOKSTORIES || Social.FacebookStories,
-    PAGESMANAGER: constants.PAGESMANAGER || Social.Pagesmanager,
-    TWITTER: constants.TWITTER || Social.Twitter,
-    WHATSAPP: constants.WHATSAPP || Social.Whatsapp,
-    WHATSAPPBUSINESS: constants.WHATSAPPBUSINESS || Social.Whatsappbusiness,
-    INSTAGRAM: constants.INSTAGRAM || Social.Instagram,
-    INSTAGRAM_STORIES: constants.INSTAGRAMSTORIES || Social.InstagramStories,
-    GOOGLEPLUS: constants.GOOGLEPLUS || Social.Googleplus,
-    EMAIL: constants.EMAIL || Social.Email,
-    PINTEREST: constants.PINTEREST || Social.Pinterest,
-    LINKEDIN: constants.LINKEDIN || Social.Linkedin,
-    SMS: constants.SMS || Social.Sms,
-    TELEGRAM: constants.TELEGRAM || Social.Telegram,
-    MESSENGER: constants.MESSENGER || Social.Messenger,
-    SNAPCHAT: constants.SNAPCHAT || Social.Snapchat,
-    VIBER: constants.VIBER || Social.Viber,
-    DISCORD: constants.DISCORD || Social.Discord,
+    FACEBOOK: (constants.FACEBOOK || Social.Facebook) as Social.Facebook,
+    FACEBOOK_STORIES: (constants.FACEBOOKSTORIES ||
+      Social.FacebookStories) as Social.FacebookStories,
+    PAGESMANAGER: (constants.PAGESMANAGER || Social.Pagesmanager) as Social.Pagesmanager,
+    TWITTER: (constants.TWITTER || Social.Twitter) as Social.Twitter,
+    WHATSAPP: (constants.WHATSAPP || Social.Whatsapp) as Social.Whatsapp,
+    WHATSAPPBUSINESS: (constants.WHATSAPPBUSINESS ||
+      Social.Whatsappbusiness) as Social.Whatsappbusiness,
+    INSTAGRAM: (constants.INSTAGRAM || Social.Instagram) as Social.Instagram,
+    INSTAGRAM_STORIES: (constants.INSTAGRAMSTORIES ||
+      Social.InstagramStories) as Social.InstagramStories,
+    GOOGLEPLUS: (constants.GOOGLEPLUS || Social.Googleplus) as Social.Googleplus,
+    EMAIL: (constants.EMAIL || Social.Email) as Social.Email,
+    PINTEREST: (constants.PINTEREST || Social.Pinterest) as Social.Pinterest,
+    LINKEDIN: (constants.LINKEDIN || Social.Linkedin) as Social.Linkedin,
+    SMS: (constants.SMS || Social.Sms) as Social.Sms,
+    TELEGRAM: (constants.TELEGRAM || Social.Telegram) as Social.Telegram,
+    MESSENGER: (constants.MESSENGER || Social.Messenger) as Social.Messenger,
+    SNAPCHAT: (constants.SNAPCHAT || Social.Snapchat) as Social.Snapchat,
+    VIBER: (constants.VIBER || Social.Viber) as Social.Viber,
+    DISCORD: (constants.DISCORD || Social.Discord) as Social.Discord,
   },
 
   async open(options: ShareOptions) {
@@ -76,6 +78,9 @@ const RNShare = {
     if (options.social === RNShare.Social.INSTAGRAM_STORIES && !options.appId) {
       throw new Error('To share to Instagram Stories you need to provide appId');
     }
+    if (options.social === RNShare.Social.FACEBOOK_STORIES && !options.appId) {
+      throw new Error('To share to Facebook Stories you need to provide appId');
+    }
 
     await checkPermissions(options);
 
@@ -98,7 +103,7 @@ const RNShare = {
 
     const result: IsPackageInstalledResult = {
       isInstalled,
-      message: 'Package is Installed',
+      message: isInstalled ? 'Package is Installed' : 'Package is not Installed',
     };
 
     return result;
@@ -106,7 +111,17 @@ const RNShare = {
 } as const;
 
 export { Overlay, Sheet, Button, ShareSheet, ShareAsset, Social };
-export type { ShareSingleOptions, ShareOptions, ActivityType, IsPackageInstalledResult };
+export type {
+  ShareSingleOptions,
+  ShareOptions,
+  ActivityType,
+  ActivityItem,
+  ActivityItemSource,
+  LinkMetadata,
+  ShareOpenResult,
+  ShareSingleResult,
+  IsPackageInstalledResult,
+} from './types';
 export type { OverlayProps } from './components/Overlay';
 export type { SheetProps } from './components/Sheet';
 export type { ButtonProps } from './components/Button';

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,11 +57,13 @@ interface BaseShareSingleOptions {
   url?: string;
   type?: string;
   filename?: string;
+  filenames?: string[];
   message?: string;
   title?: string;
   subject?: string;
   email?: string;
   recipient?: string;
+  whatsAppNumber?: string;
   social: Exclude<Social, Social.FacebookStories | Social.InstagramStories>;
   forceDialog?: boolean;
   /** Android Only: Store the temporary file in the internal storage cache */
@@ -113,6 +115,8 @@ export interface ShareOptions {
   isNewTask?: boolean;
   /** iOS Only */
   disableOverlay?: boolean;
+  /** iOS Only: React tag of the view anchoring the iPad popover. */
+  anchor?: number;
   /** Android Only: Store the temporary file in the internal storage cache */
   useInternalStorage?: boolean;
 }


### PR DESCRIPTION
## Fixes

- Read native constants once instead of 18 bridge calls; preserve native overrides and enum fallbacks.
- Skip obsolete base64/permission bridge work on Android API 19+; preserve pre-19 grants/denials.
- Preserve an explicitly supplied `urls` array when `url` is also provided.
- Reject missing Facebook Stories app IDs before native work, matching the existing Instagram guard.
- Give all 18 exported social constants their precise enum type; expose existing result/metadata types and supported `whatsAppNumber`, `filenames` and popover `anchor` options.
- Make the installed-package message agree with its boolean.

## Compatibility / behavior changes

Explicit `urls` now takes precedence over the single URL in normalization. Invalid Facebook Stories calls reject earlier. The message for an absent Android package changes to "Package is not Installed"; consumers should use `isInstalled`. Native constant values and result shapes are unchanged. Stories still require an app ID in typed code.

Modern Android no longer performs unnecessary storage-permission work for app-specific cache. This does not grant arbitrary file access. [Android storage requirements](https://developer.android.com/training/data-storage/app-specific).

## Test plan

21 standalone JS controls pass on the isolated patch, plus a strict TypeScript consumer covering all 18 constants, documented fields, exported types and negative cases. Baseline reproduces the contract failures. Isolated ESLint/TypeScript and combined package build pass. No checked-in test/spec files were added or changed. Standalone diagnostics use actual source; OS/framework doubles are identified below. Physical-device social-app delivery and manual screen-reader verification are not claimed.

Based on `a2d1594c58fbe2e2cea5a4aae4f65ee71dc77630`; independent of the native patches.


## Downstream verification

The combined reviewed runtime fixes are adopted in our React Native 0.87.1 app through immutable 12.3.1-based artifact `a2af29ba70fa3cdb23c231b0de5e0de148cb9bbf` (source backport `c25ac3400f7cd721eba6cfcce6c6630e788237d1`). This artifact combines the runtime PRs; it is not an isolated test of only this PR. Package contents and generated entrypoints were checked against the installed artifact.

Immutable install, CocoaPods, app ESLint, 13 production web targets, all browser-extension builds, both Trackstats/Socialstats Android Debug builds, both unsigned arm64 iOS Simulator Debug builds and four separate production Metro bundles pass. Simulator builds use `SKIP_BUNDLING=1`; bundling was verified separately. Existing build/peer warnings remain. No physical-device delivery, signed release or deployment claim.
