### PR TITLE
fix(expo): merge package queries from the current Android manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "babel-jest": "^29.7.0",
     "eslint": "^8.53.0",
     "eslint-config-satya164": "^3.2.0",
-    "expo-build-properties": "^0.13.1",
     "husky": "^4.3.0",
     "jest": "^29.7.0",
     "lint-staged": "^15.0.2",

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -1,29 +1,4 @@
-import * as fs from 'fs';
-
-import { ExportedConfig } from '@expo/config-plugins';
-import { withBuildProperties } from 'expo-build-properties';
-
-/**
- * Handles for edge case when LSApplicationQueriesSchemes is an object or undefined.
- */
-const getIOSQuerySchemes = (config: ExportedConfig): string[] => {
-  return Array.isArray(config.ios?.infoPlist?.LSApplicationQueriesSchemes)
-    ? config.ios?.infoPlist?.LSApplicationQueriesSchemes ?? []
-    : [];
-};
-
-/**
- * Currently there are noway to get manifest queries config directly
- * So we parse AndroidManifest.xml to get the queries packages.
- */
-export function getManifestQueriesPackagesSync(manifestPath: string): string[] {
-  if (!fs.existsSync(manifestPath)) return [];
-  const xml = fs.readFileSync(manifestPath, 'utf8');
-  const queriesSection = xml.match(/<queries>[\s\S]*?<\/queries>/);
-  if (!queriesSection) return [];
-  const matches = [...queriesSection[0].matchAll(/<package[^>]*android:name="([^"]+)"[^>]*\/>/g)];
-  return matches.map((m) => m[1]);
-}
+import { ExportedConfig, withAndroidManifest } from '@expo/config-plugins';
 
 export default (
   config: ExportedConfig,
@@ -31,33 +6,11 @@ export default (
     enableBase64ShareAndroid?: boolean;
     android?: string[];
     ios?: string[];
-  },
-) => {
-  let manifestPath = './android/app/src/main/AndroidManifest.xml';
-  if (config.android?.publishManifestPath) {
-    manifestPath = config.android.publishManifestPath;
-  }
-  const currentManifestQueries = getManifestQueriesPackagesSync(manifestPath);
-  const updatedManifestQueries = (props.android ?? []).filter(
-    (p) => !currentManifestQueries.includes(p),
-  );
+  } = {},
+): ExportedConfig => {
+  const currentSchemes = config.ios?.infoPlist?.LSApplicationQueriesSchemes;
 
-  const propConfig = {
-    android: {},
-  };
-
-  /**
-   * manifestQueries.package = [] would crashes the prebuild
-   */
-  if (updatedManifestQueries.length > 0) {
-    propConfig.android = {
-      manifestQueries: {
-        package: updatedManifestQueries,
-      },
-    };
-  }
-
-  return withBuildProperties(
+  return withAndroidManifest(
     {
       ...config,
       android: {
@@ -77,10 +30,33 @@ export default (
         ...config.ios,
         infoPlist: {
           ...config.ios?.infoPlist,
-          LSApplicationQueriesSchemes: [...getIOSQuerySchemes(config), ...(props?.ios ?? [])],
+          LSApplicationQueriesSchemes: [
+            ...new Set([
+              ...(Array.isArray(currentSchemes) ? currentSchemes : []),
+              ...(props.ios ?? []),
+            ]),
+          ],
         },
       },
     },
-    propConfig,
+    (modConfig) => {
+      if (!props.android?.length) return modConfig;
+
+      const queries = (modConfig.modResults.manifest.queries ??= []);
+      const packages = new Set(
+        queries.flatMap((query) => (query.package ?? []).map((item) => item.$['android:name'])),
+      );
+      if (!queries.length) queries.push({});
+
+      for (const packageName of props.android) {
+        if (!packages.has(packageName)) {
+          (queries[0].package ??= []).push({
+            $: { 'android:name': packageName },
+          });
+          packages.add(packageName);
+        }
+      }
+      return modConfig;
+    },
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4947,18 +4947,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^8.11.0":
-  version: 8.17.1
-  resolution: "ajv@npm:8.17.1"
-  dependencies:
-    fast-deep-equal: "npm:^3.1.3"
-    fast-uri: "npm:^3.0.1"
-    json-schema-traverse: "npm:^1.0.0"
-    require-from-string: "npm:^2.0.2"
-  checksum: 10c0/ec3ba10a573c6b60f94639ffc53526275917a2df6810e4ab5a6b959d87459f9ef3f00d5e7865b82677cb7d21590355b34da14d1d0b9c32d75f95a187e76fff35
-  languageName: node
-  linkType: hard
-
 "anser@npm:^1.4.9":
   version: 1.4.10
   resolution: "anser@npm:1.4.10"
@@ -7889,18 +7877,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-build-properties@npm:^0.13.1":
-  version: 0.13.1
-  resolution: "expo-build-properties@npm:0.13.1"
-  dependencies:
-    ajv: "npm:^8.11.0"
-    semver: "npm:^7.6.0"
-  peerDependencies:
-    expo: "*"
-  checksum: 10c0/b565f6f995371ce0be526dcab45dba504f82934d8fffdf38ce2f46d1e7497e25df80d38e0fa4e4e7203a6d557bc4190a840e9eb8c94a5c205b0285777945c8fd
-  languageName: node
-  linkType: hard
-
 "exponential-backoff@npm:^3.1.1":
   version: 3.1.1
   resolution: "exponential-backoff@npm:3.1.1"
@@ -7953,13 +7929,6 @@ __metadata:
   version: 2.0.6
   resolution: "fast-levenshtein@npm:2.0.6"
   checksum: 10c0/111972b37338bcb88f7d9e2c5907862c280ebf4234433b95bc611e518d192ccb2d38119c4ac86e26b668d75f7f3894f4ff5c4982899afced7ca78633b08287c4
-  languageName: node
-  linkType: hard
-
-"fast-uri@npm:^3.0.1":
-  version: 3.1.2
-  resolution: "fast-uri@npm:3.1.2"
-  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
   languageName: node
   linkType: hard
 
@@ -10628,13 +10597,6 @@ __metadata:
   version: 0.4.1
   resolution: "json-schema-traverse@npm:0.4.1"
   checksum: 10c0/108fa90d4cc6f08243aedc6da16c408daf81793bf903e9fd5ab21983cda433d5d2da49e40711da016289465ec2e62e0324dcdfbc06275a607fe3233fde4942ce
-  languageName: node
-  linkType: hard
-
-"json-schema-traverse@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "json-schema-traverse@npm:1.0.0"
-  checksum: 10c0/71e30015d7f3d6dc1c316d6298047c8ef98a06d31ad064919976583eb61e1018a60a0067338f0f79cabc00d84af3fcc489bd48ce8a46ea165d9541ba17fb30c6
   languageName: node
   linkType: hard
 
@@ -14358,7 +14320,6 @@ __metadata:
     babel-jest: "npm:^29.7.0"
     eslint: "npm:^8.53.0"
     eslint-config-satya164: "npm:^3.2.0"
-    expo-build-properties: "npm:^0.13.1"
     husky: "npm:^4.3.0"
     jest: "npm:^29.7.0"
     lint-staged: "npm:^15.0.2"
@@ -14795,13 +14756,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"require-from-string@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "require-from-string@npm:2.0.2"
-  checksum: 10c0/aaa267e0c5b022fc5fd4eef49d8285086b15f2a1c54b28240fdf03599cbd9c26049fee3eab894f2e1f6ca65e513b030a7c264201e3f005601e80c49fb2937ce2
-  languageName: node
-  linkType: hard
-
 "require-in-the-middle@npm:^7.1.1":
   version: 7.2.0
   resolution: "require-in-the-middle@npm:7.2.0"
@@ -15185,7 +15139,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.1.1, semver@npm:^7.1.2, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.1, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0":
+"semver@npm:^7.1.1, semver@npm:^7.1.2, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.1, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4":
   version: 7.6.3
   resolution: "semver@npm:7.6.3"
   bin:


### PR DESCRIPTION
## Fixes

- Merge package queries into the manifest produced by the current Expo mod pipeline, instead of filtering against a stale on-disk XML file.
- Preserve existing package queries, intent queries, provider queries and other manifest sections.
- Deduplicate requested/existing Android packages and iOS URL schemes; repeated prebuilds are idempotent.
- Accept omitted plugin options and emit an explicit portable return type. The latter prevents TS2742 when declaration generation resolves dependencies through a symlink.
- Remove the now-unused `expo-build-properties` dependency and its orphaned lockfile entries.

## Compatibility / potentially breaking internal usage

The documented plugin options remain supported, including the existing explicit `enableBase64ShareAndroid` opt-in.

The undocumented `getManifestQueriesPackagesSync` export is removed. Consumers importing that helper directly must migrate; `android.publishManifestPath` is no longer consulted because the plugin uses the actual in-memory manifest. There is no supported main-package API change.

## Test plan

- Eight standalone checks using the installed Expo mod implementation pass on this isolated patch; six fail on the unmodified baseline.
- Covered: omitted options, repeated scheme/permission configuration, absent queries, existing/requested duplicates, reruns, preserved intent/provider sections, and a clean prebuild with a stale on-disk manifest.
- Isolated ESLint (zero warnings), plugin TypeScript/declaration build and diff checks pass. The declaration build reproduces TS2742 before the return annotation and passes afterward.
- Dependency installation and the combined package validation/build pass.
- No checked-in tests changed. This is not a claim of a full Expo native application build.

Based on `a2d1594c58fbe2e2cea5a4aae4f65ee71dc77630`; independent of the JS/native share fixes.


## Downstream verification

The combined reviewed runtime fixes are adopted in our React Native 0.87.1 app through immutable 12.3.1-based artifact `a2af29ba70fa3cdb23c231b0de5e0de148cb9bbf` (source backport `c25ac3400f7cd721eba6cfcce6c6630e788237d1`). This artifact combines the runtime PRs; it is not an isolated test of only this PR. Package contents and generated entrypoints were checked against the installed artifact.

Immutable install, CocoaPods, app ESLint, 13 production web targets, all browser-extension builds, both Trackstats/Socialstats Android Debug builds, both unsigned arm64 iOS Simulator Debug builds and four separate production Metro bundles pass. Simulator builds use `SKIP_BUNDLING=1`; bundling was verified separately. Existing build/peer warnings remain. No physical-device delivery, signed release or deployment claim.
