### PR TITLE
fix(ui): make share sheets interruptible and accessible

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -25,8 +25,13 @@ const Button: React.FC<ButtonProps> = ({
   textStyle,
   children,
 }: ButtonProps) => (
-  <TouchableOpacity activeOpacity={0.5} style={[styles.button, buttonStyle]} onPress={onPress}>
-    <Image style={styles.icon} source={iconSrc} />
+  <TouchableOpacity
+    activeOpacity={0.5}
+    style={[styles.button, buttonStyle]}
+    onPress={onPress}
+    accessibilityRole="button"
+  >
+    <Image style={styles.icon} source={iconSrc} accessible={false} />
     <Text style={[styles.buttonText, textStyle]}>{children}</Text>
   </TouchableOpacity>
 );
@@ -37,13 +42,14 @@ const styles = StyleSheet.create({
   button: {
     backgroundColor: 'white',
     flexDirection: 'row',
-    height: 50,
+    minHeight: 50,
     padding: 10,
   },
   buttonText: {
     color: '#2c2c2c',
     fontSize: 16,
     fontWeight: 'bold',
+    flexShrink: 1,
     textAlign: 'left',
     textAlignVertical: 'center',
   },

--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Animated, StyleProp, StyleSheet, ViewStyle } from 'react-native';
+import { Animated, Easing, StyleProp, StyleSheet, ViewStyle } from 'react-native';
 
 const DEFAULT_ANIMATE_TIME = 300;
 const styles = StyleSheet.create({
@@ -24,27 +24,40 @@ export interface OverlayProps {
 }
 
 const Overlay: React.FC<React.PropsWithChildren<OverlayProps>> = ({ visible, children }) => {
-  const [fadeAnim] = React.useState(new Animated.Value(0));
+  const [fadeAnim] = React.useState(() => new Animated.Value(0));
   const [overlayStyle, setOverlayStyle] = React.useState<StyleProp<ViewStyle>>(styles.emptyOverlay);
-
-  const onAnimatedEnd = React.useCallback(() => {
-    if (!visible) {
-      setOverlayStyle(styles.emptyOverlay);
-    }
-  }, [visible]);
 
   React.useEffect(() => {
     if (visible) {
       setOverlayStyle(styles.fullOverlay);
     }
-    return Animated.timing(fadeAnim, {
+    let active = true;
+    const animation = Animated.timing(fadeAnim, {
       toValue: visible ? 1 : 0,
       duration: DEFAULT_ANIMATE_TIME,
-      useNativeDriver: false,
-    }).start(onAnimatedEnd);
-  }, [visible, fadeAnim, onAnimatedEnd]);
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: true,
+    });
+    animation.start(({ finished }) => {
+      if (active && finished && !visible) setOverlayStyle(styles.emptyOverlay);
+    });
+    return () => {
+      active = false;
+      animation.stop();
+    };
+  }, [visible, fadeAnim]);
 
-  return <Animated.View style={[overlayStyle, { opacity: fadeAnim }]}>{children}</Animated.View>;
+  return (
+    <Animated.View
+      style={[overlayStyle, { opacity: fadeAnim }]}
+      pointerEvents={visible ? 'auto' : 'none'}
+      accessibilityElementsHidden={!visible}
+      importantForAccessibility={visible ? 'auto' : 'no-hide-descendants'}
+      accessibilityViewIsModal={visible}
+    >
+      {children}
+    </Animated.View>
+  );
 };
 
 export default Overlay;

--- a/src/components/ShareSheet.tsx
+++ b/src/components/ShareSheet.tsx
@@ -14,6 +14,7 @@ import Sheet from './Sheet';
 export interface ShareSheetProps {
   visible: boolean;
   onCancel: () => void;
+  cancelAccessibilityLabel?: string;
   style?: StyleProp<ViewStyle>;
   overlayStyle?: StyleProp<ViewStyle>;
 }
@@ -23,27 +24,29 @@ const ShareSheet: React.FC<React.PropsWithChildren<ShareSheetProps>> = ({
   overlayStyle = {},
   visible,
   onCancel,
+  cancelAccessibilityLabel = 'Cancel sharing',
   children,
 }) => {
-  const backButtonHandler = React.useCallback(() => {
-    if (visible) {
+  React.useEffect(() => {
+    if (!visible) return;
+    const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
       onCancel();
       return true;
-    }
-    return false;
-  }, [visible, onCancel]);
-
-  React.useEffect(() => {
-    const subscription = BackHandler.addEventListener('hardwareBackPress', backButtonHandler);
+    });
     return () => {
       subscription.remove();
     };
-  }, [backButtonHandler]);
+  }, [visible, onCancel]);
 
   return (
     <Overlay visible={visible}>
-      <View style={[styles.actionSheetContainer, overlayStyle]}>
-        <TouchableOpacity style={styles.button} onPress={onCancel} />
+      <View style={[styles.actionSheetContainer, overlayStyle]} onAccessibilityEscape={onCancel}>
+        <TouchableOpacity
+          style={styles.button}
+          onPress={onCancel}
+          accessibilityRole="button"
+          accessibilityLabel={cancelAccessibilityLabel}
+        />
         <Sheet visible={visible}>
           <View style={[styles.buttonContainer, style]}>{children}</View>
         </Sheet>

--- a/src/components/Sheet.tsx
+++ b/src/components/Sheet.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { Animated } from 'react-native';
+import { AccessibilityInfo, Animated, Easing } from 'react-native';
 
-const DEFAULT_BOTTOM = -300;
+const DEFAULT_OFFSET = 300;
 const DEFAULT_ANIMATE_TIME = 300;
 
 export interface SheetProps {
@@ -9,17 +9,50 @@ export interface SheetProps {
 }
 
 const Sheet: React.FC<React.PropsWithChildren<SheetProps>> = ({ visible, children }) => {
-  const [bottom] = React.useState(new Animated.Value(DEFAULT_BOTTOM));
+  const [offset] = React.useState(() => new Animated.Value(DEFAULT_OFFSET));
+  const [reduceMotion, setReduceMotion] = React.useState(true);
 
   React.useEffect(() => {
-    return Animated.timing(bottom, {
-      toValue: visible ? 0 : DEFAULT_BOTTOM,
-      duration: DEFAULT_ANIMATE_TIME,
-      useNativeDriver: false,
-    }).start();
-  }, [visible, bottom]);
+    let initialQueryPending = true;
+    const subscription = AccessibilityInfo.addEventListener('reduceMotionChanged', (enabled) => {
+      initialQueryPending = false;
+      setReduceMotion(enabled);
+    });
+    AccessibilityInfo.isReduceMotionEnabled()
+      .then((enabled) => {
+        if (initialQueryPending) setReduceMotion(enabled);
+        return null;
+      })
+      .catch(() => {
+        // Keep motion disabled if the platform preference cannot be read.
+      });
+    return () => {
+      initialQueryPending = false;
+      subscription.remove();
+    };
+  }, []);
 
-  return <Animated.View style={{ bottom }}>{children}</Animated.View>;
+  React.useEffect(() => {
+    const animation = Animated.timing(offset, {
+      toValue: visible ? 0 : DEFAULT_OFFSET,
+      duration: reduceMotion ? 0 : DEFAULT_ANIMATE_TIME,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: true,
+    });
+    animation.start();
+    return () => animation.stop();
+  }, [visible, offset, reduceMotion]);
+
+  return (
+    <Animated.View
+      style={{ transform: [{ translateY: offset }] }}
+      pointerEvents={visible ? 'auto' : 'none'}
+      accessibilityElementsHidden={!visible}
+      importantForAccessibility={visible ? 'auto' : 'no-hide-descendants'}
+    >
+      {children}
+    </Animated.View>
+  );
 };
 
 export default Sheet;

--- a/website/docs/ui-components.mdx
+++ b/website/docs/ui-components.mdx
@@ -5,17 +5,42 @@ title: UI Components
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-TODO:
+`ShareSheet`, `Button`, `Overlay` and `Sheet` are optional React Native UI components, available as named exports or on the default `Share` export. They do not launch native sharing themselves: call `Share.open` or `Share.shareSingle` from your button handler.
 
-- Write docs about the `components` exported [here](https://github.com/react-native-community/react-native-share/tree/5299d95aab25bfba6815e0f5455876897ed8ddc6/components) and [here](https://github.com/react-native-community/react-native-share/blob/5299d95aab25bfba6815e0f5455876897ed8ddc6/index.js#L50-L82)
+```jsx
+import Share, { ShareSheet, Button } from 'react-native-share';
+
+<ShareSheet
+  visible={shareSheetVisible}
+  onCancel={() => setShareSheetVisible(false)}
+  cancelAccessibilityLabel="Close sharing options"
+>
+  <Button iconSrc={shareIcon} onPress={handleShare}>
+    Share link
+  </Button>
+</ShareSheet>
+```
+
+Your `handleShare` callback should handle the sharing promise and close the sheet at the appropriate time for your flow.
+
+| Component | Props |
+| --- | --- |
+| `ShareSheet` | Required `visible` and `onCancel`; optional `style`, `overlayStyle` and `cancelAccessibilityLabel` (defaults to `Cancel sharing`). |
+| `Button` | Required `onPress`, `iconSrc` and text children; optional `buttonStyle` and `textStyle`. |
+| `Overlay` / `Sheet` | Required `visible`; render content as children. |
+
+The sheet handles Android Back while visible and exposes an accessibility escape action. Localize `cancelAccessibilityLabel` for your app. Hidden content does not accept touches or appear in the accessibility tree. Buttons expose their role and grow with their text instead of imposing a fixed height.
+
+The overlay fades while the sheet slides using native-driven animations. Interrupting or unmounting stops the previous animation; a stale closing animation cannot hide a reopened overlay. With the system's reduced-motion setting enabled, the slide is immediate and the overlay retains its fade. Motion stays disabled while the initial preference is unknown.
+
+These are in-tree views, not a native `Modal`. The hosting screen remains responsible for focus placement/restoration, keyboard access, and any additional modal isolation it needs. Verify the complete screen with your supported assistive technologies.
 
 ## How it looks
 
 ### Android
 
-<img alt="Demo Android UI Component" src={useBaseUrl('img/assets-docs/android-component-250x.gif')} />
+<a href={useBaseUrl('img/assets-docs/android-component-250x.gif')}>Open the animated Android component demonstration</a>
 
 ### iOS
 
-<img alt="Demo iOS UI Component" src={useBaseUrl('img/assets-docs/ios-component-250x.gif')} />
-
+<a href={useBaseUrl('img/assets-docs/ios-component-250x.gif')}>Open the animated iOS component demonstration</a>


### PR DESCRIPTION
## Fixes and compatibility

Share-sheet animations now stop on interruption/unmount, ignore stale completion callbacks, and respect reduced motion. Hidden sheets no longer intercept touches, accessibility navigation or Android Back. Cancel controls have explicit labels and escape behavior; share buttons expose button semantics and hide decorative icons.

Sheet motion uses native-driven `translateY` rather than animated layout. Public component props remain compatible; `cancelAccessibilityLabel` is additive. Motion/hidden interaction behavior intentionally changes.

| Before | After | Why |
| --- | --- | --- |
| Animated layout and stale close callbacks | Native-driven transform/opacity with owned cleanup | Avoid per-frame JS layout and interrupted-close races |
| Always-on motion | Reduced-motion subscription with safe initial state | Respect the OS preference, including late initial queries |
| Hidden content could intercept Back/touch/focus | Hidden interaction/accessibility disabled | Keep invisible UI out of navigation |

**Verdict: Approve the scoped implementation.** Device animation feel, VoiceOver/TalkBack focus traversal and every custom child layout remain manual verification limits; this is not an accessibility conformance claim.

## Test plan

14 standalone actual-component diagnostics pass on this isolated patch; all 14 fail on baseline. Isolated lint, TypeScript and diff checks pass. React Doctor reports two Reanimated preferences: these transitions already use the native driver; adding a runtime dependency solely for that rule is not justified. No checked-in test/spec files were added or changed. Standalone diagnostics use actual source; OS/framework doubles are identified below. Physical-device social-app delivery and manual screen-reader verification are not claimed.

Based on `a2d1594c58fbe2e2cea5a4aae4f65ee71dc77630`.


## Downstream verification

The combined reviewed runtime fixes are adopted in our React Native 0.87.1 app through immutable 12.3.1-based artifact `a2af29ba70fa3cdb23c231b0de5e0de148cb9bbf` (source backport `c25ac3400f7cd721eba6cfcce6c6630e788237d1`). This artifact combines the runtime PRs; it is not an isolated test of only this PR. Package contents and generated entrypoints were checked against the installed artifact.

Immutable install, CocoaPods, app ESLint, 13 production web targets, all browser-extension builds, both Trackstats/Socialstats Android Debug builds, both unsigned arm64 iOS Simulator Debug builds and four separate production Metro bundles pass. Simulator builds use `SKIP_BUNDLING=1`; bundling was verified separately. Existing build/peer warnings remain. No physical-device delivery, signed release or deployment claim.
