### PR TITLE
fix(android): own share callbacks and preserve attachment routing

### DIFF
--- a/android/src/main/java/cl/json/RNShareImpl.java
+++ b/android/src/main/java/cl/json/RNShareImpl.java
@@ -7,12 +7,10 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import android.net.Uri;
 
-import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.Promise;
-import com.facebook.react.bridge.WritableMap;
 
 import cl.json.social.EmailShare;
 import cl.json.social.FacebookShare;
@@ -46,23 +44,10 @@ public class RNShareImpl implements ActivityEventListener {
 
     public static final String NAME = "RNShare";
 
-    static ReactApplicationContext RCTContext = null;
-
-    public static final int SHARE_REQUEST_CODE = 16845;
+    private final ReactApplicationContext RCTContext;
 
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (requestCode == SHARE_REQUEST_CODE) {
-            if (resultCode == Activity.RESULT_CANCELED) {
-                WritableMap reply = Arguments.createMap();
-                reply.putBoolean("success", false);
-                reply.putString("message", "CANCELED");
-                TargetChosenReceiver.callbackResolve(reply);
-            } else if (resultCode == Activity.RESULT_OK) {
-                WritableMap reply = Arguments.createMap();
-                reply.putBoolean("success", true);
-                TargetChosenReceiver.callbackResolve(reply);
-            }
-        }
+        TargetChosenReceiver.onActivityResult(RCTContext, requestCode, resultCode);
     }
     
     @Override
@@ -147,6 +132,11 @@ public class RNShareImpl implements ActivityEventListener {
         RCTContext.addActivityEventListener(this);
     }
 
+    public void invalidate() {
+        RCTContext.removeActivityEventListener(this);
+        TargetChosenReceiver.invalidate(RCTContext);
+    }
+
     public Map<String, Object> getConstants() {
         Map<String, Object> constants = new HashMap<>();
         for (SHARES val : SHARES.values()) {
@@ -156,23 +146,25 @@ public class RNShareImpl implements ActivityEventListener {
     }
 
     public void open(ReadableMap options, Promise promise) {
-        TargetChosenReceiver.registerCallbacks(promise);
+        TargetChosenReceiver request = TargetChosenReceiver.registerCallbacks(promise, RCTContext);
+        if (request == null) return;
         try {
             GenericShare share = new GenericShare(RCTContext);
             share.open(options);
         } catch (ActivityNotFoundException ex) {
             Log.e(NAME,ex.getMessage());
             ex.printStackTrace(System.out);
-            TargetChosenReceiver.callbackReject("not_available");
+            request.callbackReject("not_available");
         } catch (Exception e) {
             Log.e(NAME,e.getMessage());
             e.printStackTrace(System.out);
-            TargetChosenReceiver.callbackReject(e.getMessage());
+            request.callbackReject(e.getMessage());
         }
     }
 
     public void shareSingle(ReadableMap options, Promise promise) {
-        TargetChosenReceiver.registerCallbacks(promise);
+        TargetChosenReceiver request = TargetChosenReceiver.registerCallbacks(promise, RCTContext);
+        if (request == null) return;
         if (ShareIntent.hasValidKey("social", options)) {
             try {
                 ShareIntent shareClass = SHARES.getShareClass(options.getString("social"), RCTContext);
@@ -184,14 +176,14 @@ public class RNShareImpl implements ActivityEventListener {
             } catch (ActivityNotFoundException ex) {
                 Log.e(NAME,ex.getMessage());
                 ex.printStackTrace(System.out);
-                TargetChosenReceiver.callbackReject(ex.getMessage());
+                request.callbackReject(ex.getMessage());
             } catch (Exception e) {
                 Log.e(NAME,e.getMessage());
                 e.printStackTrace(System.out);
-                TargetChosenReceiver.callbackReject(e.getMessage());
+                request.callbackReject(e.getMessage());
             }
         } else {
-            TargetChosenReceiver.callbackReject("key 'social' missing in options");
+            request.callbackReject("key 'social' missing in options");
         }
     }
 

--- a/android/src/main/java/cl/json/ShareFile.java
+++ b/android/src/main/java/cl/json/ShareFile.java
@@ -10,6 +10,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.UUID;
 
 /**
  * Created by disenodosbbcl on 22-07-16.
@@ -19,58 +20,42 @@ public class ShareFile {
     public static final int BASE_64_DATA_LENGTH = 5; // `data:`
     public static final int BASE_64_DATA_OFFSET = 8; // `;base64,`
     private final ReactApplicationContext reactContext;
-    private String url;
-    private Uri uri;
+    private final Uri uri;
     private String type;
-    private String filename;
-    private Boolean useInternalStorage;
+    private final String filename;
+    private final Boolean useInternalStorage;
+    private boolean filenameIncludesExtension;
+    private Uri sharedUri;
 
-    public ShareFile(String url, String type, String filename, Boolean useInternalStorage, ReactApplicationContext reactContext){
+    public ShareFile(String url, String type, String filename, Boolean useInternalStorage, ReactApplicationContext reactContext) {
         this(url, filename, useInternalStorage, reactContext);
         this.type = type;
     }
 
-    public ShareFile(String url, String filename, Boolean useInternalStorage, ReactApplicationContext reactContext){
-        this.url = url;
-        this.uri = Uri.parse(this.url);
+    public ShareFile(String url, String filename, Boolean useInternalStorage, ReactApplicationContext reactContext) {
+        this.uri = Uri.parse(url);
         this.filename = filename;
         this.useInternalStorage = useInternalStorage;
         this.reactContext = reactContext;
     }
-    /**
-     * Obtain mime type from URL
-     * @param url {@link String}
-     * @return {@link String} mime type
-     */
-    private String getMimeType(String url) {
-        String type = null;
-        String extension = MimeTypeMap.getFileExtensionFromUrl(url);
-        if (extension != null) {
-            type = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
-        }
-        return type;
+
+    ShareFile(String url, String type, String filename, Boolean useInternalStorage, ReactApplicationContext reactContext, boolean filenameIncludesExtension) {
+        this(url, type, filename, useInternalStorage, reactContext);
+        this.filenameIncludesExtension = filenameIncludesExtension;
     }
-    /**
-     * Return an if the url is a file (local or base64)l
-     * @return {@link boolean}
-     */
+
     public boolean isFile() {
         return this.isBase64File() || this.isLocalFile();
     }
 
     private boolean isBase64File() {
-        String scheme = uri.getScheme();
-        if((scheme != null) && uri.getScheme().equals("data")) {
-            StringBuilder type = new StringBuilder();
-            char[] parts = this.uri.toString().substring(BASE_64_DATA_LENGTH).toCharArray();
-            for (char part : parts) {
-                if (part == ';') {
-                    break;
-                }
-                type.append(part);
+        if ("data".equals(uri.getScheme())) {
+            String value = uri.toString();
+            int separator = value.indexOf(';', BASE_64_DATA_LENGTH);
+            if (separator < 0 || value.indexOf(";base64,", separator) < 0) {
+                throw new IllegalArgumentException("Invalid base64 data URI");
             }
-
-            this.type = type.toString();
+            this.type = separator == BASE_64_DATA_LENGTH ? "text/plain" : value.substring(BASE_64_DATA_LENGTH, separator);
             return true;
         }
         return false;
@@ -78,74 +63,72 @@ public class ShareFile {
 
     private boolean isLocalFile() {
         String scheme = uri.getScheme();
-        if((scheme != null) && (uri.getScheme().equals("content") || uri.getScheme().equals("file"))) {
-            // type is already set
-            if (this.type != null) {
-                return true;
-            }
-            // try to get mimetype from uri
-            this.type = this.getMimeType(uri.toString());
-
-            // try resolving the file and get the mimetype
-            if(this.type == null) {
-              String realPath = this.getRealPathFromURI(uri);
-              if (realPath != null) {
-                  this.type = this.getMimeType(realPath);
-              } else {
-                  return false;
-              }
-            }
-
-            if(this.type == null) {
-              this.type = "*/*";
-            }
-
-            return true;
+        if (!"content".equals(scheme) && !"file".equals(scheme)) {
+            return false;
         }
-        return false;
-    }
-    public String getType() {
+        if (this.type == null && "content".equals(scheme)) {
+            this.type = reactContext.getContentResolver().getType(uri);
+        }
         if (this.type == null) {
-           return "*/*";
+            String extension = MimeTypeMap.getFileExtensionFromUrl(uri.toString());
+            this.type = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
         }
-        return this.type;
+        if (this.type == null) {
+            this.type = "*/*";
+        }
+        return true;
     }
-    private String getRealPathFromURI(Uri contentUri) {
-        String result = RNSharePathUtil.getRealPathFromURI(this.reactContext,  contentUri, this.useInternalStorage);
-        return result;
+
+    public String getType() {
+        return this.type == null ? "*/*" : this.type;
     }
+
     public Uri getURI() {
+        if (sharedUri != null) return sharedUri;
 
-        final MimeTypeMap mime = MimeTypeMap.getSingleton();
-        String extension = mime.getExtensionFromMimeType(getType());
+        if (this.isBase64File()) {
+            String value = uri.toString();
+            String encoded = value.substring(value.indexOf(";base64,") + BASE_64_DATA_OFFSET);
+            // Decode before opening a file, so invalid data cannot leak a stream.
+            byte[] data = Base64.decode(encoded, Base64.DEFAULT);
+            String name = filename == null ? "file" : filename;
+            if (name.isEmpty() || name.equals(".") || name.equals("..") || name.contains("/") || name.contains("\\")) {
+                throw new IllegalArgumentException("Filename must be a non-empty file name without directory separators");
+            }
+            if (filename == null || !filenameIncludesExtension) {
+                String extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(getType());
+                if (extension != null) name += "." + extension;
+            }
 
-        if(this.isBase64File()) {
-            String encodedImg = this.uri.toString().substring(BASE_64_DATA_LENGTH + this.type.length() + BASE_64_DATA_OFFSET);
-            String filename = this.filename != null ? this.filename : System.nanoTime() + "";
+            File cacheDir = Boolean.TRUE.equals(useInternalStorage) ? reactContext.getCacheDir() : reactContext.getExternalCacheDir();
+            if (cacheDir == null) cacheDir = reactContext.getCacheDir();
+            File downloads = new File(cacheDir, Environment.DIRECTORY_DOWNLOADS);
+            // Each attachment owns its directory, even when display names are identical.
+            File dir = new File(downloads, UUID.randomUUID().toString());
+            File file = new File(dir, name);
             try {
-                File cacheDir = this.useInternalStorage ? this.reactContext.getCacheDir() : this.reactContext.getExternalCacheDir();
-                File dir = new File(cacheDir, Environment.DIRECTORY_DOWNLOADS);
-                if (!dir.exists() && !dir.mkdirs()) {
-                    throw new IOException("mkdirs failed on " + dir.getAbsolutePath());
+                if (!dir.mkdirs()) {
+                    throw new IOException("Unable to create the share cache directory");
                 }
-                File file = new File(dir, filename + "." + extension);
-                final FileOutputStream fos = new FileOutputStream(file);
-                fos.write(Base64.decode(encodedImg, Base64.DEFAULT));
-                fos.flush();
-                fos.close();
-                return RNSharePathUtil.compatUriFromFile(reactContext, file);
-
+                try (FileOutputStream stream = new FileOutputStream(file)) {
+                    stream.write(data);
+                }
+                sharedUri = RNSharePathUtil.compatUriFromFile(reactContext, file);
+                if (sharedUri == null) {
+                    throw new IOException("Unable to create a content URI for the shared file");
+                }
             } catch (IOException e) {
-                e.printStackTrace();
+                file.delete();
+                dir.delete();
+                throw new IllegalStateException("Unable to prepare the shared file", e);
             }
-        } else if(this.isLocalFile()) {
-            Uri uri = Uri.parse(this.url);
-            if (uri.getPath() == null) {
-                return null;
+        } else if (this.isLocalFile()) {
+            if ("content".equals(uri.getScheme())) {
+                sharedUri = uri;
+            } else if (uri.getPath() != null) {
+                sharedUri = RNSharePathUtil.compatUriFromFile(reactContext, new File(uri.getPath()));
             }
-            return RNSharePathUtil.compatUriFromFile(reactContext, new File(uri.getPath()));
         }
-
-        return null;
+        return sharedUri;
     }
 }

--- a/android/src/main/java/cl/json/ShareFiles.java
+++ b/android/src/main/java/cl/json/ShareFiles.java
@@ -1,173 +1,69 @@
 package cl.json;
 
 import android.net.Uri;
-import android.os.Environment;
-import android.util.Base64;
-import android.webkit.MimeTypeMap;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableArray;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 
 /**
  * Created by bhavesh on 11/08/17.
  */
-
-public class ShareFiles
-{
-    private final ReactApplicationContext reactContext;
-    private ArrayList<Uri> uris;
-    private ArrayList<String> filenames;
+public class ShareFiles {
+    private final ArrayList<ShareFile> files = new ArrayList<>();
     private String intentType;
-    private Boolean useInternalStorage;
 
     public ShareFiles(ReadableArray urls, ArrayList<String> filenames, String type, Boolean useInternalStorage, ReactApplicationContext reactContext) {
-        this(urls, filenames, useInternalStorage, reactContext);
+        for (int i = 0; i < urls.size(); i++) {
+            String url = urls.getString(i);
+            if (url != null) {
+                String filename = i < filenames.size() ? filenames.get(i) : null;
+                files.add(new ShareFile(url, type, filename, useInternalStorage, reactContext, true));
+            }
+        }
         this.intentType = type;
     }
 
     public ShareFiles(ReadableArray urls, ArrayList<String> filenames, Boolean useInternalStorage, ReactApplicationContext reactContext) {
-        this.uris = new ArrayList<>();
-        for (int i = 0; i < urls.size(); i++) {
-            String url = urls.getString(i);
-            if (url != null) {
-                Uri uri = Uri.parse(url);
-                this.uris.add(uri);
-            }
-        }
-        this.filenames = filenames;
-        this.useInternalStorage = useInternalStorage;
-        this.reactContext = reactContext;
+        this(urls, filenames, null, useInternalStorage, reactContext);
     }
-    /**
-     * Obtain mime type from URL
-     * @param url {@link String}
-     * @return {@link String} mime type
-     */
-    private String getMimeType(String url) {
-        String type = null;
-        String extension = MimeTypeMap.getFileExtensionFromUrl(url);
-        if (extension != null) {
-            type = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
-        }
-        return type;
-    }
-    /**
-     * Return an if the url is a file (local or base64)l
-     * @return {@link boolean}
-     */
+
     public boolean isFile() {
-        boolean isFile = true;
-        for (Uri uri : this.uris) {
-            isFile = this.isBase64File(uri) || this.isLocalFile(uri);
-            if (!isFile) {
-                break;
+        if (files.isEmpty()) return false;
+
+        for (ShareFile file : files) {
+            if (!file.isFile()) return false;
+
+            String type = file.getType();
+            if (intentType == null) {
+                intentType = type;
+            } else if (!intentType.equalsIgnoreCase(type)) {
+                int separator = intentType.indexOf('/');
+                int typeSeparator = type.indexOf('/');
+                if (separator > 0 && typeSeparator > 0 && intentType.substring(0, separator).equalsIgnoreCase(type.substring(0, typeSeparator))) {
+                    intentType = intentType.substring(0, separator) + "/*";
+                } else {
+                    intentType = "*/*";
+                }
             }
         }
-        return isFile;
-    }
-
-    private boolean isBase64File(Uri uri) {
-        String scheme = uri.getScheme();
-        if((scheme != null) && uri.getScheme().equals("data")) {
-            String type = uri.getSchemeSpecificPart().substring(0, uri.getSchemeSpecificPart().indexOf(";"));
-            if (this.intentType == null) {
-                this.intentType = type;
-            } else if (!this.intentType.equalsIgnoreCase(type) && this.intentType.split("/")[0].equalsIgnoreCase((type.split("/"))[0])) {
-                this.intentType = (this.intentType.split("/")[0]).concat("/*");
-            } else if (!this.intentType.equalsIgnoreCase(type)) {
-                this.intentType = "*/*";
-            }
-            return true;
-        }
-        return false;
-    }
-    private boolean isLocalFile(Uri uri) {
-        String scheme = uri.getScheme();
-        if((scheme != null) && uri.getScheme().equals("content") || "file".equals(uri.getScheme())) {
-//            // type is already set
-//            if (this.type != null) {
-//                return true;
-//            }
-            // try to get mimetype from uri
-            String type = this.getMimeType(uri.toString());
-
-            // try resolving the file and get the mimetype
-            if(type == null) {
-                String realPath = this.getRealPathFromURI(uri);
-                type = this.getMimeType(realPath);
-            }
-            if(type == null) {
-                type = "*/*";
-            }
-
-            if (this.intentType == null) {
-                this.intentType = type;
-            } else if (!this.intentType.equalsIgnoreCase(type) && this.intentType.split("/")[0].equalsIgnoreCase((type.split("/"))[0])) {
-                this.intentType = (this.intentType.split("/")[0]).concat("/*");
-            } else if (!this.intentType.equalsIgnoreCase(type)) {
-                this.intentType = "*/*";
-            }
-
-            return true;
-        }
-        return false;
+        return true;
     }
 
     public String getType() {
-        if (this.intentType == null) {
-            return "*/*";
-        }
-        return this.intentType;
-    }
-
-    private String getRealPathFromURI(Uri contentUri) {
-        String result = RNSharePathUtil.getRealPathFromURI(this.reactContext, contentUri, this.useInternalStorage);
-        return result;
+        return intentType == null ? "*/*" : intentType;
     }
 
     public ArrayList<Uri> getURI() {
-        final MimeTypeMap mime = MimeTypeMap.getSingleton();
-        ArrayList<Uri> finalUris = new ArrayList<>();
-
-        for (int uriIndex = 0; uriIndex < this.uris.size(); uriIndex++) {
-            Uri uri = this.uris.get(uriIndex);
-
-            if(this.isBase64File(uri)) {
-                String type = uri.getSchemeSpecificPart().substring(0, uri.getSchemeSpecificPart().indexOf(";"));
-                String extension = mime.getExtensionFromMimeType(type);
-                String encodedImg = uri.getSchemeSpecificPart().substring(uri.getSchemeSpecificPart().indexOf(";base64,") + 8);
-                String fileName = filenames.size() >= uriIndex + 1 ? filenames.get(uriIndex) : (System.currentTimeMillis() + "." + extension);
-                try {
-                    File cacheDir = this.useInternalStorage ? this.reactContext.getCacheDir() : this.reactContext.getExternalCacheDir();
-                    File dir = new File(cacheDir, Environment.DIRECTORY_DOWNLOADS);
-                    if (!dir.exists() && !dir.mkdirs()) {
-                        throw new IOException("mkdirs failed on " + dir.getAbsolutePath());
-                    }
-                    File file = new File(dir, fileName);
-                    final FileOutputStream fos = new FileOutputStream(file);
-                    fos.write(Base64.decode(encodedImg, Base64.DEFAULT));
-                    fos.flush();
-                    fos.close();
-                    finalUris.add(RNSharePathUtil.compatUriFromFile(reactContext, file));
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            } else if(this.isLocalFile(uri)) {
-                if (uri.getPath() != null) {
-                    if (filenames.size() >= uriIndex + 1) {
-                        finalUris.add(RNSharePathUtil.compatUriFromFile(reactContext, new File(uri.getPath(), filenames.get(uriIndex))));
-                    } else {
-                        finalUris.add(RNSharePathUtil.compatUriFromFile(reactContext, new File(uri.getPath())));
-                    }
-                }
+        ArrayList<Uri> uris = new ArrayList<>(files.size());
+        for (ShareFile file : files) {
+            Uri uri = file.getURI();
+            if (uri == null) {
+                throw new IllegalStateException("Unable to prepare a shared file URI");
             }
+            uris.add(uri);
         }
-
-        return finalUris;
+        return uris;
     }
 }

--- a/android/src/main/java/cl/json/social/FacebookStoriesShare.java
+++ b/android/src/main/java/cl/json/social/FacebookStoriesShare.java
@@ -28,6 +28,10 @@ public class FacebookStoriesShare extends SingleShareIntent {
     @Override
     public void open(ReadableMap options) throws ActivityNotFoundException, IllegalArgumentException {
         super.open(options);
+        if (isFallback) {
+            super.openIntentChooser();
+            return;
+        }
         this.shareStory(options);
         // extra params here
         this.openIntentChooser(options);
@@ -61,8 +65,7 @@ public class FacebookStoriesShare extends SingleShareIntent {
         Activity activity = this.reactContext.getCurrentActivity();
 
         if (activity == null) {
-            TargetChosenReceiver.callbackReject("Something went wrong");
-            return;
+            throw new ActivityNotFoundException("No activity available to share Facebook stories");
         }
 
         this.intent.putExtra("com.facebook.platform.extra.APPLICATION_ID", options.getString("appId"));
@@ -91,17 +94,19 @@ public class FacebookStoriesShare extends SingleShareIntent {
 
         if (hasBackgroundAsset) {
             String backgroundFileName = "";
+            String backgroundType = "image/jpeg";
 
             if (this.hasValidKey("backgroundImage", options)) {
                 backgroundFileName = options.getString("backgroundImage");
             } else if (this.hasValidKey("backgroundVideo", options)) {
                 backgroundFileName = options.getString("backgroundVideo");
+                backgroundType = "video/*";
             }
 
-            ShareFile backgroundAsset = new ShareFile(backgroundFileName, "image/jpeg", "background", useInternalStorage, this.reactContext);
+            ShareFile backgroundAsset = new ShareFile(backgroundFileName, backgroundType, "background", useInternalStorage, this.reactContext);
 
             this.intent.setDataAndType(backgroundAsset.getURI(), backgroundAsset.getType());
-            this.intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            this.intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         }
 
         if (this.hasValidKey("stickerImage", options)) {
@@ -111,8 +116,9 @@ public class FacebookStoriesShare extends SingleShareIntent {
                 this.intent.setType("image/*");
             }
 
-            this.intent.putExtra("interactive_asset_uri", stickerAsset.getURI());
-            activity.grantUriPermission("com.facebook.katana", stickerAsset.getURI(),
+            Uri stickerUri = stickerAsset.getURI();
+            this.intent.putExtra("interactive_asset_uri", stickerUri);
+            activity.grantUriPermission("com.facebook.katana", stickerUri,
                     Intent.FLAG_GRANT_READ_URI_PERMISSION);
         }
     }

--- a/android/src/main/java/cl/json/social/InstagramShare.java
+++ b/android/src/main/java/cl/json/social/InstagramShare.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.net.Uri;
-import android.util.Log;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -28,10 +27,18 @@ public class InstagramShare extends SingleShareIntent {
     @Override
     public void open(ReadableMap options) throws ActivityNotFoundException {
             super.open(options);
+            if (isFallback) {
+                super.openIntentChooser();
+                return;
+            }
+
+            if (ShareIntent.hasValidKey("url", options) && options.getString("url").startsWith("instagram://")) {
+                openInstagramUrlScheme(options.getString("url"));
+                return;
+            }
 
             if (!ShareIntent.hasValidKey("type", options)) {
-                Log.e("RNShare", "No type provided");
-                return;
+                throw new IllegalArgumentException("No type provided");
             }
             String type = options.getString("type");
 
@@ -41,16 +48,9 @@ public class InstagramShare extends SingleShareIntent {
             }
 
             if (!ShareIntent.hasValidKey("url", options)) {
-                Log.e("RNShare", "No url provided");
-                return;
+                throw new IllegalArgumentException("No url provided");
             }
             String url = options.getString("url");
-
-            Boolean isUrlScheme = url.startsWith("instagram://");
-            if (isUrlScheme) {
-                openInstagramUrlScheme(url);
-                return;
-            }
 
             String extension = this.getExtension(type);
             Boolean isImage = type.startsWith("image");
@@ -78,11 +78,18 @@ public class InstagramShare extends SingleShareIntent {
     }
 
     protected void openInstagramIntentChooserForMedia(String url, String chooserTitle, Boolean isImage, String extension) {
+        Activity activity = this.reactContext.getCurrentActivity();
+        if (activity == null) {
+            throw new ActivityNotFoundException("No activity available to share Instagram media");
+        }
         Boolean shouldUseInternalStorage = ShareIntent.hasValidKey("useInternalStorage", options) && options.getBoolean("useInternalStorage");
         ShareFile shareFile = isImage 
             ? new ShareFile(url, "image/" + extension, "image", shouldUseInternalStorage, this.reactContext) 
             : new ShareFile(url, "video/" + extension, "video", shouldUseInternalStorage, this.reactContext);
-        Uri uri = shareFile.getURI();
+        Uri uri = fileUri != null ? fileUri : shareFile.getURI();
+        if (uri == null) {
+            throw new IllegalArgumentException("Unable to prepare Instagram media");
+        }
 
         Intent feedIntent = new Intent(Intent.ACTION_SEND);
 
@@ -93,11 +100,12 @@ public class InstagramShare extends SingleShareIntent {
         }
 
         feedIntent.putExtra(Intent.EXTRA_STREAM, uri);
+        feedIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         feedIntent.setPackage(PACKAGE);
 
         Intent storiesIntent = new Intent("com.instagram.share.ADD_TO_STORY");
 
-        storiesIntent.setDataAndType(uri, extension);
+        storiesIntent.setDataAndType(uri, isImage ? "image/*" : "video/*");
 
         storiesIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         storiesIntent.setPackage(PACKAGE);
@@ -106,14 +114,13 @@ public class InstagramShare extends SingleShareIntent {
         chooserIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, new Intent[] {storiesIntent});
 
-        Activity activity = this.reactContext.getCurrentActivity();
         activity.grantUriPermission(PACKAGE, uri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
         this.reactContext.startActivity(chooserIntent);
 
         WritableMap reply = Arguments.createMap();
         reply.putBoolean("success", true);
         reply.putString("message", this.getIntent().getPackage());
-        TargetChosenReceiver.callbackResolve(reply);
+        shareRequest.callbackResolve(reply);
     }
 
     @Override

--- a/android/src/main/java/cl/json/social/InstagramStoriesShare.java
+++ b/android/src/main/java/cl/json/social/InstagramStoriesShare.java
@@ -28,6 +28,10 @@ public class InstagramStoriesShare extends SingleShareIntent {
     @Override
     public void open(ReadableMap options) throws ActivityNotFoundException {
         super.open(options);
+        if (isFallback) {
+            super.openIntentChooser();
+            return;
+        }
         this.shareStory(options);
         //  extra params here
         this.openIntentChooser(options);
@@ -57,8 +61,7 @@ public class InstagramStoriesShare extends SingleShareIntent {
         Activity activity = this.reactContext.getCurrentActivity();
 
         if (activity == null) {
-            TargetChosenReceiver.callbackReject("Something went wrong");
-            return;
+            throw new ActivityNotFoundException("No activity available to share Instagram stories");
         }
 
         this.intent.putExtra("source_application", options.getString("appId"));
@@ -108,7 +111,7 @@ public class InstagramStoriesShare extends SingleShareIntent {
             ShareFile backgroundAsset = new ShareFile(backgroundFileName, backgroundType, "background", useInternalStorage, this.reactContext);
 
             this.intent.setDataAndType(backgroundAsset.getURI(), backgroundAsset.getType());
-            this.intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            this.intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         }
 
         if (this.hasValidKey("stickerImage", options)) {
@@ -118,8 +121,9 @@ public class InstagramStoriesShare extends SingleShareIntent {
                 this.intent.setType("image/*");
             }
 
-            this.intent.putExtra("interactive_asset_uri", stickerAsset.getURI());
-            activity.grantUriPermission(InstagramStoriesShare.PACKAGE, stickerAsset.getURI(),
+            Uri stickerUri = stickerAsset.getURI();
+            this.intent.putExtra("interactive_asset_uri", stickerUri);
+            activity.grantUriPermission(InstagramStoriesShare.PACKAGE, stickerUri,
                     Intent.FLAG_GRANT_READ_URI_PERMISSION);
         }
     }

--- a/android/src/main/java/cl/json/social/ShareIntent.java
+++ b/android/src/main/java/cl/json/social/ShareIntent.java
@@ -21,15 +21,14 @@ import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
 
 import java.io.UnsupportedEncodingException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 
-import cl.json.RNShareImpl;
 import cl.json.ShareFile;
 import cl.json.ShareFiles;
 
@@ -39,15 +38,18 @@ import cl.json.ShareFiles;
 public abstract class ShareIntent {
 
     protected final ReactApplicationContext reactContext;
+    protected final TargetChosenReceiver shareRequest;
     protected Intent intent;
     protected String chooserTitle = "Share";
     protected ShareFile fileShare;
+    protected Uri fileUri;
     protected ReadableMap options;
     protected ShareFile stickerAsset;
     protected ShareFile backgroundAsset;
 
     public ShareIntent(ReactApplicationContext reactContext) {
         this.reactContext = reactContext;
+        this.shareRequest = TargetChosenReceiver.getCurrentRequest(reactContext);
         this.setIntent(new Intent(android.content.Intent.ACTION_SEND));
         this.getIntent().setType("text/plain");
     }
@@ -56,6 +58,7 @@ public abstract class ShareIntent {
         List<Intent> targetedShareIntents = new ArrayList<Intent>();
         List<HashMap<String, String>> intentMetaInfo = new ArrayList<HashMap<String, String>>();
         Intent chooserIntent;
+        HashSet<String> excludedPackages = getExcludedPackages(options.getArray("excludedActivityTypes"));
 
         Intent dummy = new Intent(prototype.getAction());
         dummy.setType(prototype.getType());
@@ -63,7 +66,7 @@ public abstract class ShareIntent {
 
         if (!resInfo.isEmpty()) {
             for (ResolveInfo resolveInfo : resInfo) {
-                if (resolveInfo.activityInfo == null || options.getArray("excludedActivityTypes").toString().contains(resolveInfo.activityInfo.packageName))
+                if (resolveInfo.activityInfo == null || excludedPackages.contains(resolveInfo.activityInfo.packageName))
                     continue;
 
                 HashMap<String, String> info = new HashMap<String, String>();
@@ -90,13 +93,16 @@ public abstract class ShareIntent {
                     targetedShareIntents.add(targetedShareIntent);
                 }
 
-                chooserIntent = Intent.createChooser(targetedShareIntents.remove(targetedShareIntents.size() - 1), "share");
+                Intent target = targetedShareIntents.remove(targetedShareIntents.size() - 1);
+                chooserIntent = TargetChosenReceiver.isSupported()
+                        ? Intent.createChooser(target, chooserTitle, shareRequest.getSharingSenderIntent())
+                        : Intent.createChooser(target, chooserTitle);
                 chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, targetedShareIntents.toArray(new Parcelable[]{}));
                 return chooserIntent;
             }
         }
 
-        return Intent.createChooser(prototype, "Share");
+        throw new ActivityNotFoundException("No share targets remain after exclusions");
     }
 
     public void open(ReadableMap options) throws ActivityNotFoundException {
@@ -128,7 +134,7 @@ public abstract class ShareIntent {
             socialType = options.getString("social");
         }
 
-        if (socialType.equals("sms")) {
+        if (socialType.equals("sms") && hasValidKey("recipient", options)) {
             String recipient = options.getString("recipient");
 
             if (!recipient.isEmpty()) {
@@ -152,11 +158,15 @@ public abstract class ShareIntent {
             }
         }
 
-        if (ShareIntent.hasValidKey("urls", options)) {
+        if (ShareIntent.hasValidKey("urls", options) && options.getArray("urls").size() > 0) {
 
             ShareFiles fileShare = getFileShares(options);
             if (fileShare.isFile()) {
                 ArrayList<Uri> uriFile = fileShare.getURI();
+                if (uriFile.isEmpty()) {
+                    throw new IllegalArgumentException("No files to share");
+                }
+                if (uriFile.size() == 1) this.fileUri = uriFile.get(0);
 
                 ClipData clip = new ClipData(new ClipDescription("Files", new String[]{fileShare.getType()}), new ClipData.Item(uriFile.get(0)));
 
@@ -183,6 +193,10 @@ public abstract class ShareIntent {
             this.fileShare = getFileShare(options);
             if (this.fileShare.isFile()) {
                 Uri uriFile = this.fileShare.getURI();
+                if (uriFile == null) {
+                    throw new IllegalArgumentException("Unable to prepare the shared file URI");
+                }
+                this.fileUri = uriFile;
                 ClipData clip = ClipData.newUri(this.reactContext.getContentResolver(), "File", uriFile);
                 this.getIntent().setType(this.fileShare.getType());
                 this.getIntent().setClipData(clip);
@@ -242,7 +256,7 @@ public abstract class ShareIntent {
 
     protected static String urlEncode(String param) {
         try {
-            return URLEncoder.encode(param, "UTF-8");
+            return URLEncoder.encode(param == null ? "" : param, "UTF-8");
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException("URLEncoder.encode() failed for " + param);
         }
@@ -252,9 +266,9 @@ public abstract class ShareIntent {
         PackageManager pm = this.reactContext.getPackageManager();
 
         List<ResolveInfo> resInfo = pm.queryIntentActivities(intent, 0);
-        Intent[] extraIntents = new Intent[resInfo.size()];
-        for (int i = 0; i < resInfo.size(); i++) {
-            ResolveInfo ri = resInfo.get(i);
+        ArrayList<Intent> extraIntents = new ArrayList<>(resInfo.size());
+        for (ResolveInfo ri : resInfo) {
+            if (ri.activityInfo == null) continue;
             String packageName = ri.activityInfo.packageName;
 
             Intent newIntent = new Intent();
@@ -262,33 +276,33 @@ public abstract class ShareIntent {
             newIntent.setAction(Intent.ACTION_VIEW);
             newIntent.setDataAndType(uri, intent.getType());
             newIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-            extraIntents[i] = new Intent(newIntent);
+            extraIntents.add(newIntent);
         }
 
-        return extraIntents;
+        return extraIntents.toArray(new Intent[0]);
     }
 
     protected void openIntentChooser() throws ActivityNotFoundException {
         Activity activity = this.reactContext.getCurrentActivity();
         if (activity == null) {
-            TargetChosenReceiver.callbackReject("Something went wrong");
+            shareRequest.callbackReject("Something went wrong");
             return;
         }
         Intent chooser;
         IntentSender intentSender = null;
         if (TargetChosenReceiver.isSupported()) {
-            intentSender = TargetChosenReceiver.getSharingSenderIntent(this.reactContext);
+            intentSender = shareRequest.getSharingSenderIntent();
             chooser = Intent.createChooser(this.getIntent(), this.chooserTitle, intentSender);
         } else {
             chooser = Intent.createChooser(this.getIntent(), this.chooserTitle);
         }
         chooser.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
 
-        if (ShareIntent.hasValidKey("showAppsToView", options) && ShareIntent.hasValidKey("url", options)) {
+        if (ShareIntent.hasValidKey("showAppsToView", options) && options.getBoolean("showAppsToView") && fileUri != null) {
             Intent viewIntent = new Intent(Intent.ACTION_VIEW);
-            viewIntent.setType(this.fileShare.getType());
+            viewIntent.setType(this.getIntent().getType());
 
-            Intent[] viewIntents = this.getIntentsToViewFile(viewIntent, this.fileShare.getURI());
+            Intent[] viewIntents = this.getIntentsToViewFile(viewIntent, fileUri);
 
             chooser.putExtra(Intent.EXTRA_INITIAL_INTENTS, viewIntents);
         }
@@ -296,26 +310,27 @@ public abstract class ShareIntent {
         if (ShareIntent.hasValidKey("excludedActivityTypes", options)) {
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
                 chooser.putExtra(Intent.EXTRA_EXCLUDE_COMPONENTS, getExcludedComponentArray(options.getArray("excludedActivityTypes")));
-                activity.startActivityForResult(chooser, RNShareImpl.SHARE_REQUEST_CODE);
+                activity.startActivityForResult(chooser, shareRequest.getRequestCode());
             } else {
-                activity.startActivityForResult(excludeChooserIntent(this.getIntent(),options), RNShareImpl.SHARE_REQUEST_CODE);
+                activity.startActivityForResult(excludeChooserIntent(this.getIntent(),options), shareRequest.getRequestCode());
             }
         } else {
-            activity.startActivityForResult(chooser, RNShareImpl.SHARE_REQUEST_CODE);
+            activity.startActivityForResult(chooser, shareRequest.getRequestCode());
         }
 
         if (intentSender == null) {
             WritableMap reply = Arguments.createMap();
             reply.putBoolean("success", true);
             reply.putString("message", "OK");
-            TargetChosenReceiver.callbackResolve(reply);
+            shareRequest.callbackResolve(reply);
         }
     }
 
     public static boolean isPackageInstalled(String packagename, Context context) {
+        if (packagename == null) return false;
         PackageManager pm = context.getPackageManager();
         try {
-            pm.getPackageInfo(packagename, PackageManager.GET_ACTIVITIES);
+            pm.getPackageInfo(packagename, 0);
             return true;
         } catch (PackageManager.NameNotFoundException e) {
             return false;
@@ -351,15 +366,23 @@ public abstract class ShareIntent {
         Intent dummy = new Intent(getIntent().getAction());
         dummy.setType(getIntent().getType());
         List<ComponentName> componentNameList = new ArrayList<>();
+        HashSet<String> excludedPackages = getExcludedPackages(excludeActivityTypes);
         List<ResolveInfo> resInfoList = this.reactContext.getPackageManager().queryIntentActivities(dummy, 0);
-        for (int index = 0; index < excludeActivityTypes.size(); index++) {
-            String packageName = excludeActivityTypes.getString(index);
-            for(ResolveInfo resInfo : resInfoList) {
-                if(resInfo.activityInfo.packageName.equals(packageName)) {
-                    componentNameList.add(new ComponentName(resInfo.activityInfo.packageName, resInfo.activityInfo.name));
-                }
+        for (ResolveInfo resInfo : resInfoList) {
+            if (resInfo.activityInfo != null && excludedPackages.contains(resInfo.activityInfo.packageName)) {
+                componentNameList.add(new ComponentName(resInfo.activityInfo.packageName, resInfo.activityInfo.name));
             }
         }
         return componentNameList.toArray(new ComponentName[]{});
+    }
+
+    private static HashSet<String> getExcludedPackages(ReadableArray activityTypes) {
+        HashSet<String> packages = new HashSet<>();
+        if (activityTypes != null) {
+            for (int i = 0; i < activityTypes.size(); i++) {
+                packages.add(activityTypes.getString(i));
+            }
+        }
+        return packages;
     }
 }

--- a/android/src/main/java/cl/json/social/SingleShareIntent.java
+++ b/android/src/main/java/cl/json/social/SingleShareIntent.java
@@ -7,13 +7,14 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
 import android.net.Uri;
+import android.os.Handler;
+import android.os.Looper;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 
-import cl.json.RNShareImpl;
 
 /**
  * Created by disenodosbbcl on 23-07-16.
@@ -22,17 +23,17 @@ public abstract class SingleShareIntent extends ShareIntent {
 
     protected String playStoreURL = null;
     protected String appStoreURL = null;
+    protected boolean isFallback;
 
     public SingleShareIntent(ReactApplicationContext reactContext) {
         super(reactContext);
     }
 
     public void open(ReadableMap options) throws ActivityNotFoundException {
-        System.out.println(getPackage());
+        isFallback = false;
         //  check if package is installed
         if (getPackage() != null || getDefaultWebLink() != null || getPlayStoreLink() != null) {
             if (this.isPackageInstalled(getPackage(), reactContext)) {
-                System.out.println("INSTALLED");
                 if (getComponentClass() != null) {
                     ComponentName cn = new ComponentName(getPackage(), getComponentClass());
                     this.getIntent().setComponent(cn);
@@ -42,7 +43,6 @@ public abstract class SingleShareIntent extends ShareIntent {
                 super.open(options);
                 return; // once we open we don't need to continue
             } else {
-                System.out.println("NOT INSTALLED");
                 String url = "";
                 if (getDefaultWebLink() != null) {
                     url = getDefaultWebLink()
@@ -54,7 +54,11 @@ public abstract class SingleShareIntent extends ShareIntent {
                     //  TODO
                 }
                 //  open web intent
-                this.setIntent(new Intent(new Intent("android.intent.action.VIEW", Uri.parse(url))));
+                this.setIntent(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+                this.options = options;
+                if (ShareIntent.hasValidKey("title", options)) chooserTitle = options.getString("title");
+                isFallback = true;
+                return;
             }
         }
         //  configure default
@@ -65,11 +69,36 @@ public abstract class SingleShareIntent extends ShareIntent {
         this.openIntentChooser(null);
     }
 
+    protected void openIntentChooserWithConversation(String conversationClass) {
+        Handler handler = new Handler(Looper.getMainLooper());
+        handler.post(() -> {
+            if (!shareRequest.isActive()) return;
+            Intent conversation = new Intent(getIntent());
+            conversation.setComponent(new ComponentName(getPackage(), conversationClass));
+            conversation.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            try {
+                // Create the recipient's conversation without completing the actual share.
+                reactContext.startActivity(conversation);
+            } catch (ActivityNotFoundException | SecurityException ignored) {
+                // The normal share may still work if this optional activity is unavailable.
+            }
+            // Preserve the short foreground window without blocking the native module thread.
+            handler.postDelayed(() -> {
+                if (!shareRequest.isActive()) return;
+                try {
+                    openIntentChooser();
+                } catch (RuntimeException error) {
+                    shareRequest.callbackReject(error.getMessage());
+                }
+            }, 10);
+        });
+    }
+
     protected void openIntentChooser(ReadableMap options) throws ActivityNotFoundException {
-        if (this.options.hasKey("forceDialog") && this.options.getBoolean("forceDialog")) {
+        if (ShareIntent.hasValidKey("forceDialog", this.options) && this.options.getBoolean("forceDialog")) {
             Activity activity = this.reactContext.getCurrentActivity();
             if (activity == null) {
-                TargetChosenReceiver.callbackReject("Something went wrong");
+                shareRequest.callbackReject("Something went wrong");
                 return;
             }
             if (options != null) {
@@ -78,19 +107,19 @@ public abstract class SingleShareIntent extends ShareIntent {
                 }
             }
             if (TargetChosenReceiver.isSupported()) {
-                IntentSender sender = TargetChosenReceiver.getSharingSenderIntent(this.reactContext);
+                IntentSender sender = shareRequest.getSharingSenderIntent();
                 Intent chooser = Intent.createChooser(this.getIntent(), this.chooserTitle, sender);
                 chooser.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
-                activity.startActivityForResult(chooser, RNShareImpl.SHARE_REQUEST_CODE);
+                activity.startActivityForResult(chooser, shareRequest.getRequestCode());
             } else {
                 Intent chooser = Intent.createChooser(this.getIntent(), this.chooserTitle);
                 chooser.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
-                activity.startActivityForResult(chooser, RNShareImpl.SHARE_REQUEST_CODE);
+                activity.startActivityForResult(chooser, shareRequest.getRequestCode());
 
                 WritableMap reply = Arguments.createMap();
                 reply.putBoolean("success", true);
                 reply.putString("message", "OK");
-                TargetChosenReceiver.callbackResolve(reply);
+                shareRequest.callbackResolve(reply);
             }
         } else {
             this.getIntent().addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
@@ -98,7 +127,7 @@ public abstract class SingleShareIntent extends ShareIntent {
             WritableMap reply = Arguments.createMap();
             reply.putBoolean("success", true);
             reply.putString("message", this.getIntent().getPackage());
-            TargetChosenReceiver.callbackResolve(reply);
+            shareRequest.callbackResolve(reply);
         }
     }
 }

--- a/android/src/main/java/cl/json/social/TargetChosenReceiver.java
+++ b/android/src/main/java/cl/json/social/TargetChosenReceiver.java
@@ -1,6 +1,7 @@
 package cl.json.social;
 
 import android.annotation.TargetApi;
+import android.app.Activity;
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
@@ -15,90 +16,147 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
 
-/**
- * Receiver to record the chosen component when sharing an Intent.
- */
+import java.util.UUID;
+
+/** Owns one share request, its chooser receiver, and its promise. */
 public class TargetChosenReceiver extends BroadcastReceiver {
     private static final String EXTRA_RECEIVER_TOKEN = "receiver_token";
     private static final Object LOCK = new Object();
+    private static TargetChosenReceiver activeRequest;
+    private static int nextRequestCode = 16845;
 
-    private static String sTargetChosenReceiveAction;
-    private static TargetChosenReceiver sLastRegisteredReceiver;
+    private final ReactContext reactContext;
+    private final Context applicationContext;
+    private final int requestCode;
+    private final String token = UUID.randomUUID().toString();
+    private Promise callback;
+    private PendingIntent pendingIntent;
+    private boolean registered;
 
-    private static Promise callback;
+    private TargetChosenReceiver(Promise callback, ReactContext context, int requestCode) {
+        this.callback = callback;
+        this.reactContext = context;
+        this.applicationContext = context.getApplicationContext();
+        this.requestCode = requestCode;
+    }
 
     public static boolean isSupported() {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1;
     }
 
-    public static void registerCallbacks(Promise promise) {
-        callback = promise;
+    public static TargetChosenReceiver registerCallbacks(Promise promise, ReactContext context) {
+        synchronized (LOCK) {
+            if (activeRequest == null) {
+                activeRequest = new TargetChosenReceiver(promise, context, nextRequestCode);
+                nextRequestCode = nextRequestCode == 65535 ? 16845 : nextRequestCode + 1;
+                return activeRequest;
+            }
+        }
+        promise.reject("EINPROGRESS", "A share request is already in progress");
+        return null;
+    }
+
+    public static TargetChosenReceiver getCurrentRequest(ReactContext context) {
+        synchronized (LOCK) {
+            if (activeRequest == null || activeRequest.reactContext != context) {
+                throw new IllegalStateException("No active share request for this context");
+            }
+            return activeRequest;
+        }
+    }
+
+    public int getRequestCode() {
+        return requestCode;
+    }
+
+    public boolean isActive() {
+        synchronized (LOCK) {
+            return callback != null;
+        }
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP_MR1)
-    public static IntentSender getSharingSenderIntent(ReactContext reactContext) {
+    public IntentSender getSharingSenderIntent() {
         synchronized (LOCK) {
-            if (sTargetChosenReceiveAction == null) {
-                sTargetChosenReceiveAction = reactContext.getPackageName() + "/" + TargetChosenReceiver.class.getName() + "_ACTION";
-            }
-            Context context = reactContext.getApplicationContext();
-            if (sLastRegisteredReceiver != null) {
-                context.unregisterReceiver(sLastRegisteredReceiver);
-            }
-            sLastRegisteredReceiver = new TargetChosenReceiver();
-            if (Build.VERSION.SDK_INT >= 34 && context.getApplicationInfo().targetSdkVersion >= 34) {
-                context.registerReceiver(sLastRegisteredReceiver, new IntentFilter(sTargetChosenReceiveAction), Context.RECEIVER_EXPORTED);
+            if (callback == null) throw new IllegalStateException("Share request has already completed");
+            if (pendingIntent != null) return pendingIntent.getIntentSender();
+            String action = reactContext.getPackageName() + "/" + TargetChosenReceiver.class.getName() + "_ACTION";
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                applicationContext.registerReceiver(this, new IntentFilter(action), Context.RECEIVER_NOT_EXPORTED);
             } else {
-                context.registerReceiver(sLastRegisteredReceiver, new IntentFilter(sTargetChosenReceiveAction));
+                applicationContext.registerReceiver(this, new IntentFilter(action));
             }
+            registered = true;
+            // A package-scoped broadcast reaches this dynamically registered receiver.
+            // It must be mutable so the chooser can fill in EXTRA_CHOSEN_COMPONENT.
+            Intent intent = new Intent(action).setPackage(reactContext.getPackageName());
+            intent.putExtra(EXTRA_RECEIVER_TOKEN, token);
+            int flags = PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_ONE_SHOT;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) flags |= PendingIntent.FLAG_MUTABLE;
+            pendingIntent = PendingIntent.getBroadcast(reactContext, requestCode, intent, flags);
+            return pendingIntent.getIntentSender();
         }
-
-        Intent intent = new Intent(sTargetChosenReceiveAction);
-        intent.setPackage(reactContext.getPackageName());
-        intent.setClass(reactContext.getApplicationContext(), TargetChosenReceiver.class);
-        intent.putExtra(EXTRA_RECEIVER_TOKEN, sLastRegisteredReceiver.hashCode());
-        final PendingIntent callback = PendingIntent.getBroadcast(reactContext, 0, intent,
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ?
-                PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_ONE_SHOT | PendingIntent.FLAG_IMMUTABLE :
-                PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_ONE_SHOT);
-
-        return callback.getIntentSender();
     }
 
     @Override
     public void onReceive(Context context, Intent intent) {
         synchronized (LOCK) {
-            if (sLastRegisteredReceiver != this) return;
-            context.getApplicationContext().unregisterReceiver(sLastRegisteredReceiver);
-            sLastRegisteredReceiver = null;
+            if (activeRequest != this || !token.equals(intent.getStringExtra(EXTRA_RECEIVER_TOKEN))) return;
         }
-        if (!intent.hasExtra(EXTRA_RECEIVER_TOKEN) || intent.getIntExtra(EXTRA_RECEIVER_TOKEN, 0) != this.hashCode()) {
-            return;
-        }
-
         ComponentName target = intent.getParcelableExtra(Intent.EXTRA_CHOSEN_COMPONENT);
         WritableMap reply = Arguments.createMap();
         reply.putBoolean("success", true);
-        if (target != null) {
-            reply.putString("message", target.flattenToString());
-            
-        } else {
-            reply.putString("message", "OK");
-        }
+        reply.putString("message", target == null ? "OK" : target.flattenToString());
         callbackResolve(reply);
     }
 
-    // public static void sendCallback(boolean isSuccess, Object reply) {
-    public static void callbackResolve(Object reply) {
-        if (callback != null) {
-            callback.resolve(reply);
+    public static void onActivityResult(ReactContext context, int requestCode, int resultCode) {
+        TargetChosenReceiver request;
+        synchronized (LOCK) {
+            request = activeRequest;
+            if (request == null || request.reactContext != context || request.requestCode != requestCode) return;
         }
-        callback = null;
+        if (resultCode == Activity.RESULT_CANCELED || resultCode == Activity.RESULT_OK) {
+            WritableMap reply = Arguments.createMap();
+            reply.putBoolean("success", resultCode == Activity.RESULT_OK);
+            reply.putString("message", resultCode == Activity.RESULT_OK ? "OK" : "CANCELED");
+            request.callbackResolve(reply);
+        }
     }
-    public static void callbackReject(String err) {
-        if (callback != null) {
-            callback.reject(err);
+
+    public static void invalidate(ReactContext context) {
+        TargetChosenReceiver request;
+        synchronized (LOCK) {
+            request = activeRequest;
+            if (request == null || request.reactContext != context) return;
         }
-        callback = null;
+        request.callbackReject("Share module was invalidated");
+    }
+
+    private Promise takeCallback() {
+        synchronized (LOCK) {
+            Promise promise = callback;
+            callback = null;
+            if (activeRequest == this) activeRequest = null;
+            if (registered) {
+                registered = false;
+                applicationContext.unregisterReceiver(this);
+            }
+            if (pendingIntent != null) {
+                pendingIntent.cancel();
+                pendingIntent = null;
+            }
+            return promise;
+        }
+    }
+
+    public void callbackResolve(Object reply) {
+        Promise promise = takeCallback();
+        if (promise != null) promise.resolve(reply);
+    }
+
+    public void callbackReject(String error) {
+        Promise promise = takeCallback();
+        if (promise != null) promise.reject(error);
     }
 }

--- a/android/src/main/java/cl/json/social/WhatsAppBusinessShare.java
+++ b/android/src/main/java/cl/json/social/WhatsAppBusinessShare.java
@@ -1,7 +1,6 @@
 package cl.json.social;
 
 import android.content.ActivityNotFoundException;
-import android.content.ComponentName;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableMap;
@@ -16,8 +15,6 @@ public class WhatsAppBusinessShare extends SingleShareIntent {
     
     private static final String START_CONVERSATION_CLASS = "com.whatsapp.Conversation";
 
-    // must be small enough so that both activities are triggered while the app is still on foreground
-    private static final int START_ACTIVITY_TIME_GAP_MS = 10; 
 
     public WhatsAppBusinessShare(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -26,25 +23,13 @@ public class WhatsAppBusinessShare extends SingleShareIntent {
     public void open(ReadableMap options) throws ActivityNotFoundException {
         super.open(options);
         
-        if (options.hasKey("whatsAppNumber")) {
-            try {                
-                // create an empty conversation in case it's not on contacts
-                this.getIntent().setComponent(new ComponentName(PACKAGE, START_CONVERSATION_CLASS)); 
-                this.openIntentChooser();
-
-                // leave room for the conversation to be created
-                Thread.sleep(START_ACTIVITY_TIME_GAP_MS);   
-
-            } catch (Exception ex) {
-                ex.printStackTrace();
-            }
+        if (ShareIntent.hasValidKey("whatsAppNumber", options)
+                && !options.getString("whatsAppNumber").isEmpty()
+                && PACKAGE.equals(getIntent().getPackage())) {
+            openIntentChooserWithConversation(START_CONVERSATION_CLASS);
+        } else {
+            openIntentChooser();
         }
-
-        // restore default behavior to share to conversation
-        this.getIntent().setComponent(null); 
-
-        //  extra params here
-        this.openIntentChooser();
     }
     @Override
     protected String getPackage() {

--- a/android/src/main/java/cl/json/social/WhatsAppShare.java
+++ b/android/src/main/java/cl/json/social/WhatsAppShare.java
@@ -1,7 +1,6 @@
 package cl.json.social;
 
 import android.content.ActivityNotFoundException;
-import android.content.ComponentName;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableMap;
@@ -16,8 +15,6 @@ public class WhatsAppShare extends SingleShareIntent {
         
     private static final String START_CONVERSATION_CLASS = "com.whatsapp.Conversation";
     
-    // must be small enough so that both activities are triggered while the app is still on foreground
-    private static final int START_ACTIVITY_TIME_GAP_MS = 10; 
 
     public WhatsAppShare(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -26,25 +23,13 @@ public class WhatsAppShare extends SingleShareIntent {
     public void open(ReadableMap options) throws ActivityNotFoundException {
         super.open(options);
         
-        if (options.hasKey("whatsAppNumber")) {
-            try {                
-                // create an empty conversation in case it's not on contacts
-                this.getIntent().setComponent(new ComponentName(PACKAGE, START_CONVERSATION_CLASS)); 
-                this.openIntentChooser();
-
-                // leave room for the conversation to be created
-                Thread.sleep(START_ACTIVITY_TIME_GAP_MS);   
-
-            } catch (Exception ex) {
-                ex.printStackTrace();
-            }
+        if (ShareIntent.hasValidKey("whatsAppNumber", options)
+                && !options.getString("whatsAppNumber").isEmpty()
+                && PACKAGE.equals(getIntent().getPackage())) {
+            openIntentChooserWithConversation(START_CONVERSATION_CLASS);
+        } else {
+            openIntentChooser();
         }
-
-        // restore default behavior to share to conversation
-        this.getIntent().setComponent(null); 
-
-        //  extra params here
-        this.openIntentChooser();
     }
     @Override
     protected String getPackage() {

--- a/android/src/main/res/xml/share_download_paths.xml
+++ b/android/src/main/res/xml/share_download_paths.xml
@@ -2,4 +2,5 @@
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <external-path name="rnshare1" path="Download/" />
     <cache-path name="rnshare2" path="/" />
+    <external-cache-path name="rnshare_external_cache" path="Download/" />
 </paths>

--- a/android/src/newarch/cl/json/RNShare.java
+++ b/android/src/newarch/cl/json/RNShare.java
@@ -22,6 +22,12 @@ public class RNShare extends NativeRNShareSpec {
         delegate = new RNShareImpl(reactContext);
     }
 
+    @Override
+    public void invalidate() {
+        delegate.invalidate();
+        super.invalidate();
+    }
+
     @NonNull
     @Override
     public String getName() {

--- a/android/src/oldarch/cl/json/RNShare.java
+++ b/android/src/oldarch/cl/json/RNShare.java
@@ -20,6 +20,12 @@ public class RNShare extends ReactContextBaseJavaModule {
     }
 
     @Override
+    public void invalidate() {
+        delegate.invalidate();
+        super.invalidate();
+    }
+
+    @Override
     public String getName() {
         return RNShareImpl.NAME;
     }

--- a/website/docs/share-open.mdx
+++ b/website/docs/share-open.mdx
@@ -62,30 +62,28 @@ When sharing a `base64` file, you will need to follow the format below:
 
 ### Android Configuration
 
-**⚠️ Important for Android API 30+ (Android 11+):**
+Base64 attachments are written to app-specific cache storage and shared through a `FileProvider` URI. The default external-cache `Download` directory and internal cache are both configured in the library's provider paths. Android 4.4 (API 19) and newer do not require storage permission for these app-specific directories; see [Android's app-specific storage documentation](https://developer.android.com/training/data-storage/app-specific#external-access-permissions).
 
-For apps targeting Android API 30 or higher, you **must** use the `useInternalStorage: true` option when sharing base64 files. This is the recommended approach for all modern Android apps.
+Use `useInternalStorage: true` to explicitly select internal cache:
 
 ```js
 Share.open({
   url: 'data:image/png;base64,<base64_data>',
-  useInternalStorage: true, // Required for Android API 30+
+  useInternalStorage: true,
 });
 ```
 
-**Note for Android API 29 and below (deprecated):**
-
-If your application still targets Android API 29 or lower, you can add the following permission to your `AndroidManifest.xml`:
+Only legacy devices below API 19 require `WRITE_EXTERNAL_STORAGE` when using external cache:
 
 ```xml
-<!-- Only works on Android API 29 (Android 10) and below - DEPRECATED -->
-<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="18" />
 ```
 
-However, please note that:
-- This permission does nothing on Android API 30+ (Android 11+)
-- Google Play Store requires apps to target at least API 34 as of current policies
-- Using `useInternalStorage: true` is the recommended solution for all apps
+This does not grant access to arbitrary files owned by other apps. For those, obtain a readable `content://` URI through the appropriate provider or picker. The library preserves content URIs instead of trying to convert them into filesystem paths.
+
+Custom attachment names must be file names, not paths. Each base64 attachment gets an isolated cache directory, so repeated names do not overwrite another attachment. Preparation failures reject the share instead of silently dropping files.
+
+Android allows one pending share request at a time. Wait for the returned promise before starting another; an overlapping request rejects with `EINPROGRESS` without replacing the first request. Chooser callbacks and activity results belong to their originating request and React context, and receivers are released when the request completes or the module is invalidated.
 
 ## Sharing a file directly
 


### PR DESCRIPTION
## Fixes

- Give each pending share its own callback, request code, receiver token and cleanup. Reject overlap without losing the first promise; ignore stale activity/broadcast results and invalidate only the owning React context.
- Deliver package-scoped chooser broadcasts, validate the request token, and cancel/unregister owned resources before settling callbacks.
- Preserve content URIs and MIME types, avoid obsolete real-path lookups, materialize each base64 attachment once into an isolated directory, and close streams on failure.
- Add the narrow external-cache `Download/` provider path. This is separate from upstream #1766's internal-files provider change.
- Preserve false/null options, optional SMS recipients, exact package exclusions and valid URI grants. Filtered legacy choosers retain their callback/title and reject when no allowed target remains.
- Keep browser/store fallback intents intact when target apps are missing; don't decode attachments for those fallbacks.
- Replace WhatsApp's blocking sleep/early success with request-owned asynchronous warmup and final launch.

## Potentially breaking behavior

Overlapping requests reject with `EINPROGRESS`. Invalid attachment names/preparation failures and fully excluded chooser targets reject instead of overwriting, silently dropping data or reintroducing excluded apps. Repeated filenames no longer overwrite other shares. Custom native integrations using the internal static `TargetChosenReceiver` callbacks or fixed `SHARE_REQUEST_CODE` must migrate to request-owned APIs. JavaScript result shapes and valid options remain unchanged.

## Test plan

75 checks: 17 actual Java file/FD controls, four provider-path model checks, 24 intent controls, 14 WhatsApp warmup controls, and 16 Android 15 emulator checks using the actual receiver with real broadcasts/PendingIntents. File/intent/platform doubles do not replace a real chooser UI or installed-social-app handoff test.

The isolated overlay passes its file/intent/warmup checks; receiver source matches the emulator-verified implementation. Combined Android Debug and new-architecture Java/codegen builds pass. New-architecture verification uses an invocation-only installed NDK 27.1 override for the old example. No checked-in test/spec files were added or changed. Standalone diagnostics use actual source; OS/framework doubles are identified below. Physical-device social-app delivery and manual screen-reader verification are not claimed.

Based on `a2d1594c58fbe2e2cea5a4aae4f65ee71dc77630`.


## Downstream verification

The combined reviewed runtime fixes are adopted in our React Native 0.87.1 app through immutable 12.3.1-based artifact `a2af29ba70fa3cdb23c231b0de5e0de148cb9bbf` (source backport `c25ac3400f7cd721eba6cfcce6c6630e788237d1`). This artifact combines the runtime PRs; it is not an isolated test of only this PR. Package contents and generated entrypoints were checked against the installed artifact.

Immutable install, CocoaPods, app ESLint, 13 production web targets, all browser-extension builds, both Trackstats/Socialstats Android Debug builds, both unsigned arm64 iOS Simulator Debug builds and four separate production Metro bundles pass. Simulator builds use `SKIP_BUNDLING=1`; bundling was verified separately. Existing build/peer warnings remain. No physical-device delivery, signed release or deployment claim.
