### PR TITLE
fix(ios): preserve share ownership and settle attachment failures

### DIFF
--- a/RNShare.podspec
+++ b/RNShare.podspec
@@ -14,7 +14,8 @@ Pod::Spec.new do |s|
 
   s.source_files  = "ios/**/*.{h,m,mm}"
 
-  s.ios.weak_framework = 'LinkPresentation'
+  s.ios.frameworks = 'MobileCoreServices'
+  s.ios.weak_frameworks = 'LinkPresentation', 'UniformTypeIdentifiers'
 
   if defined?(install_modules_dependencies()) != nil
     install_modules_dependencies(s)

--- a/ios/DiscordShare.m
+++ b/ios/DiscordShare.m
@@ -1,6 +1,5 @@
 #import "DiscordShare.h"
-#import <AVFoundation/AVFoundation.h>
-@import Photos;
+#import "RNShareUtils.h"
 
 @implementation DiscordShare
     RCT_EXPORT_MODULE();
@@ -8,21 +7,24 @@
     reject:(RCTPromiseRejectBlock)reject
     resolve:(RCTPromiseResolveBlock)resolve {
     
-    NSString *text = [RCTConvert NSString:options[@"message"]];
-    text = (NSString*)CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(NULL,(CFStringRef) text, NULL,CFSTR("!*'();:@&=+$,/?%#[]"),kCFStringEncodingUTF8));
-    
+    NSString *text = [RCTConvert NSString:options[@"message"]] ?: @"";
     NSString *url = [RCTConvert NSString:options[@"url"]];
-    
-    NSString *discordMsg = [NSString stringWithFormat:@"discord://message?text=%@", text];
-    NSString *discordMsgUrl = [NSString stringWithFormat:@"discord://message?text=%@&url%@", text, url];
+    if (text.length == 0 && url.length == 0) {
+        reject(@"EINVAL", @"A message or URL is required", nil);
+        return;
+    }
+    NSMutableArray *queryItems = [NSMutableArray arrayWithObject:[NSURLQueryItem queryItemWithName:@"text" value:text]];
+    if (url.length > 0) [queryItems addObject:[NSURLQueryItem queryItemWithName:@"url" value:url]];
+    NSURL *shareURL = [RNShareUtils URLWithString:@"discord://message" queryItems:queryItems];
 
-    NSString * urlDiscord = url ? discordMsgUrl : discordMsg;
-    NSURL * shareURL = [NSURL URLWithString:urlDiscord];
-    
-    
     if ([[UIApplication sharedApplication] canOpenURL: shareURL]) {
-        [[UIApplication sharedApplication] openURL: shareURL];
-        resolve(@[@true, @""]);
+        [[UIApplication sharedApplication] openURL:shareURL options:@{} completionHandler:^(BOOL success) {
+            if (success) {
+                resolve(@[@true, @""]);
+            } else {
+                reject(@"EUNAVAILABLE", @"Unable to open share target", nil);
+            }
+        }];
     } else {
         NSString *stringURL = @"https://apps.apple.com/us/app/discord-chat-talk-hangout/id985746746";
         NSURL *url = [NSURL URLWithString:stringURL];

--- a/ios/EmailShare.m
+++ b/ios/EmailShare.m
@@ -9,138 +9,78 @@
 #import "EmailShare.h"
 #import "RNShareUtils.h"
 
-
 @implementation EmailShare
 
-
 - (void)shareSingle:(NSDictionary *)options
-    reject:(RCTPromiseRejectBlock)reject
-    resolve:(RCTPromiseResolveBlock)resolve {
+            reject:(RCTPromiseRejectBlock)reject
+           resolve:(RCTPromiseResolveBlock)resolve {
+    NSString *message = [RCTConvert NSString:options[@"message"]] ?: @"";
+    NSString *subject = [RCTConvert NSString:options[@"subject"]] ?: @"";
+    NSString *email = [RCTConvert NSString:options[@"email"]];
+    NSArray *urls = [RCTConvert NSArray:options[@"urls"]];
+    if (message.length == 0 && subject.length == 0 && email.length == 0 && urls.count == 0) {
+        reject(@"EINVAL", @"A message, recipient, subject, or attachment is required", nil);
+        return;
+    }
+    if (![MFMailComposeViewController canSendMail]) {
+        reject(@"com.rnshare", @"Mail services are not available.", nil);
+        return;
+    }
 
-    NSLog(@"Try open view");
+    MFMailComposeViewController *mc = [[MFMailComposeViewController alloc] init];
+    mc.mailComposeDelegate = self;
+    [mc setToRecipients:email.length > 0 ? @[email] : @[]];
+    [mc setSubject:subject];
 
-    if ([options objectForKey:@"message"] && [options objectForKey:@"message"] != [NSNull null]) {
-
-        NSString *subject = @"";
-        NSString *message = @"";
-        NSString *email = @"";
-        
-        if (![MFMailComposeViewController canSendMail]) {
-            NSLog(@"Mail services are not available.");
-            NSString *errorMessage = @"Mail services are not available.";
-            NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};
-            NSError *error = [NSError errorWithDomain:@"com.rnshare" code:1 userInfo:userInfo];
-            reject(@"com.rnshare",@"Mail services are not available.",error);
-           return;
+    for (NSString *url in urls) {
+        NSURL *URL = [RCTConvert NSURL:url];
+        if (!URL) {
+            reject(@"EINVAL", @"Invalid attachment URL", nil);
+            return;
         }
-        
-        MFMailComposeViewController *mc = [[MFMailComposeViewController alloc] init];
-        
-        mc.mailComposeDelegate = self;
-
-        if ([options objectForKey:@"email"] && [options objectForKey:@"email"] != [NSNull null]) {
-            email = [RCTConvert NSString:options[@"email"]];
-        }
-
-        if ([options objectForKey:@"subject"] && [options objectForKey:@"subject"] != [NSNull null]) {
-            subject = [RCTConvert NSString:options[@"subject"]];
-        }
-
-        message = [RCTConvert NSString:options[@"message"]];
-        
-        [mc setToRecipients:@[email]];
-        [mc setSubject:subject];
-        [mc setMessageBody:message isHTML:NO];
-        
-        if ([options objectForKey:@"urls"] && [options objectForKey:@"urls"] != [NSNull null]) {
-            NSArray *urlsArray = options[@"urls"];
-
-            for (int i=0; i<urlsArray.count; i++) {
-                NSURL *URL = [RCTConvert NSURL:urlsArray[i]];
-
-                if (URL) {
-                    BOOL isDataScheme = [URL.scheme.lowercaseString isEqualToString:@"data"];
-
-                    if (URL.fileURL || isDataScheme) {
-                        NSError *error;
-                        NSData *data = [NSData dataWithContentsOfURL:URL
-                                                            options:(NSDataReadingOptions)0
-                                                            error:&error];
-                        if (!data) {
-                            reject(@"no data",@"no data",error);
-                            return;
-                        }
-
-                        NSString *mime = @"application/octet-stream";
-                        NSString *filename = @"file";
-
-                        if([options objectForKey:@"type"]){
-                            if(urlsArray.count == 1){
-                                mime = [RCTConvert NSString:options[@"type"]];
-                            } else {
-                                RCTLogWarn(@"key 'type' is ignored when it has more than one url");
-                            }
-                        }
-
-                        if([options objectForKey:@"filename"]){
-                            if(urlsArray.count == 1){
-                                filename = [RCTConvert NSString:options[@"filename"]];
-
-
-                                // add extension just like Android for consistency
-                                // file name should not include extension
-                                if(URL.isFileURL){
-                                    NSString *ext = [[URL.absoluteString componentsSeparatedByString:@"."] lastObject];
-
-                                    filename = [filename stringByAppendingString: [@"." stringByAppendingString:ext]];
-                                }
-                                else if (isDataScheme){
-                                    NSString *ext = [RNShareUtils getExtensionFromBase64: URL.absoluteString];
-
-                                    if(ext){
-                                        filename = [filename stringByAppendingString: [@"." stringByAppendingString:ext]];
-                                    }
-                                }
-                            } else {
-                                RCTLogWarn(@"key 'filename' is ignored when it has more than one url");
-                            }
-                        }
-                        else if(URL.fileURL){
-                            NSArray *parts = [URL.absoluteString componentsSeparatedByString:@"/"];
-                            filename = [parts lastObject];
-                        }
-
-                        [mc addAttachmentData:data mimeType:mime fileName:filename];
-
-                    } else {
-                        // if not a file, just append it to message
-                        message = [message stringByAppendingString: [@" " stringByAppendingString: [RCTConvert NSString:urlsArray[i]]] ];
-                        [mc setMessageBody:message isHTML:NO];
-                    }
+        BOOL isDataScheme = [URL.scheme.lowercaseString isEqualToString:@"data"];
+        if (URL.isFileURL || isDataScheme) {
+            NSError *error;
+            NSData *data = [NSData dataWithContentsOfURL:URL options:0 error:&error];
+            if (!data) {
+                reject(@"no data", @"no data", error);
+                return;
+            }
+            NSString *mime = isDataScheme ? [RNShareUtils getMimeTypeFromBase64:URL.absoluteString] : nil;
+            NSString *extension = isDataScheme ? [RNShareUtils getExtensionFromBase64:URL.absoluteString] : URL.pathExtension;
+            NSString *filename = URL.isFileURL ? URL.lastPathComponent : @"file";
+            if (urls.count == 1) {
+                NSString *customType = [RCTConvert NSString:options[@"type"]];
+                if (customType.length > 0) mime = customType;
+                NSString *customName = [RCTConvert NSString:options[@"filename"]];
+                if (customName.length > 0) {
+                    filename = extension.length > 0 ? [customName stringByAppendingPathExtension:extension] : customName;
                 }
             }
+            [mc addAttachmentData:data mimeType:mime ?: @"application/octet-stream" fileName:filename];
+        } else {
+            message = message.length > 0 ? [NSString stringWithFormat:@"%@ %@", message, url] : url;
         }
-        
-        dispatch_async(dispatch_get_main_queue(), ^{
-            UIViewController *ctrl = RCTPresentedViewController();
-          
-            // Present mail view controller on screen
-            [ctrl presentViewController:mc animated:YES completion:NULL];
-            
-            // We could fire this either here or
-            // on the finish delegate.
-            // For now, call it here for consistency with
-            // GenericShare.shareSingle
-            resolve(@[@true, @""]);
-        });
     }
+    [mc setMessageBody:message isHTML:NO];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIViewController *controller = RCTPresentedViewController();
+        if (!controller) {
+            reject(@"EUNAVAILABLE", @"No view controller available to present email", nil);
+            return;
+        }
+        [controller presentViewController:mc animated:YES completion:^{
+            resolve(@[@true, @""]);
+        }];
+    });
 }
 
--(void)mailComposeController:(MFMailComposeViewController *)controller didFinishWithResult:(MFMailComposeResult)result error:(nullable NSError *)error
-{
+- (void)mailComposeController:(MFMailComposeViewController *)controller
+         didFinishWithResult:(MFMailComposeResult)result
+                       error:(nullable NSError *)error {
     dispatch_async(dispatch_get_main_queue(), ^{
-        UIViewController *ctrl = RCTPresentedViewController();
-        [ctrl dismissViewControllerAnimated:YES completion:NULL];
+        controller.mailComposeDelegate = nil;
+        [controller dismissViewControllerAnimated:YES completion:nil];
     });
 }
 

--- a/ios/EmailShare.m
+++ b/ios/EmailShare.m
@@ -46,8 +46,10 @@
                 reject(@"no data", @"no data", error);
                 return;
             }
-            NSString *mime = isDataScheme ? [RNShareUtils getMimeTypeFromBase64:URL.absoluteString] : nil;
             NSString *extension = isDataScheme ? [RNShareUtils getExtensionFromBase64:URL.absoluteString] : URL.pathExtension;
+            NSString *mime = isDataScheme
+                ? [RNShareUtils getMimeTypeFromBase64:URL.absoluteString]
+                : [RNShareUtils getMimeTypeFromExtension:extension];
             NSString *filename = URL.isFileURL ? URL.lastPathComponent : @"file";
             if (urls.count == 1) {
                 NSString *customType = [RCTConvert NSString:options[@"type"]];

--- a/ios/FacebookStories.h
+++ b/ios/FacebookStories.h
@@ -20,5 +20,5 @@
 #import <React/RCTUtils.h>
 @interface FacebookStories : NSObject <RCTBridgeModule>
 
-- (void *) shareSingle:(NSDictionary *)options reject:(RCTPromiseRejectBlock)reject resolve:(RCTPromiseResolveBlock)resolve;
+- (void) shareSingle:(NSDictionary *)options reject:(RCTPromiseRejectBlock)reject resolve:(RCTPromiseResolveBlock)resolve;
 @end

--- a/ios/FacebookStories.m
+++ b/ios/FacebookStories.m
@@ -7,93 +7,80 @@
 //  Copyright © 2020 Facebook. All rights reserved.
 //
 
-// import RCTLog
-#import <React/RCTLog.h>
-
 #import "FacebookStories.h"
 
 @implementation FacebookStories
 RCT_EXPORT_MODULE();
 
 - (void)shareSingle:(NSDictionary *)options
-    reject:(RCTPromiseRejectBlock)reject
-    resolve:(RCTPromiseResolveBlock)resolve {
-
+            reject:(RCTPromiseRejectBlock)reject
+           resolve:(RCTPromiseResolveBlock)resolve {
+    NSString *appId = [RCTConvert NSString:options[@"appId"]];
+    if (appId.length == 0) {
+        reject(@"EINVAL", @"An appId is required", nil);
+        return;
+    }
     NSURL *urlScheme = [NSURL URLWithString:@"facebook-stories://share"];
     if (![[UIApplication sharedApplication] canOpenURL:urlScheme]) {
-        NSError* error = [self fallbackFacebook];
-        reject(@"cannot open URL",@"cannot open URL",error);
+        reject(@"cannot open URL", @"cannot open URL", [self fallbackFacebook]);
         return;
     }
 
-    // Create dictionary of assets and attribution
-    NSMutableDictionary *items = [NSMutableDictionary dictionary];
+    RCTPromiseRejectBlock rejectOnMain = ^(NSString *code, NSString *message, NSError *error) {
+        dispatch_async(dispatch_get_main_queue(), ^{ reject(code, message, error); });
+    };
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        NSMutableDictionary *items = [NSMutableDictionary dictionary];
+        items[@"com.facebook.sharedSticker.appID"] = appId;
+        for (NSString *key in @[@"backgroundImage", @"stickerImage"]) {
+            NSString *path = [RCTConvert NSString:options[key]];
+            if (path != nil) {
+                NSURL *URL = [RCTConvert NSURL:path];
+                NSData *data = URL ? [NSData dataWithContentsOfURL:URL] : nil;
+                UIImage *image = data ? [UIImage imageWithData:data] : nil;
+                NSData *png = image ? UIImagePNGRepresentation(image) : nil;
+                if (!png) {
+                    rejectOnMain(@"EINVAL", [NSString stringWithFormat:@"Unable to decode %@", key], nil);
+                    return;
+                }
+                items[[@"com.facebook.sharedSticker." stringByAppendingString:key]] = png;
+            }
+        }
+        NSString *video = [RCTConvert NSString:options[@"backgroundVideo"]];
+        if (video != nil) {
+            NSURL *URL = [RCTConvert NSURL:video];
+            NSData *data = URL ? [NSData dataWithContentsOfURL:URL] : nil;
+            if (!data) {
+                rejectOnMain(@"EINVAL", @"Unable to read background video", nil);
+                return;
+            }
+            items[@"com.facebook.sharedSticker.backgroundVideo"] = data;
+        }
+        NSString *attribution = [RCTConvert NSString:options[@"attributionURL"]];
+        if (attribution != nil) items[@"com.facebook.sharedSticker.contentURL"] = attribution;
+        items[@"com.facebook.sharedSticker.backgroundTopColor"] = [RCTConvert NSString:options[@"backgroundTopColor"]] ?: @"#906df4";
+        items[@"com.facebook.sharedSticker.backgroundBottomColor"] = [RCTConvert NSString:options[@"backgroundBottomColor"]] ?: @"#837DF4";
 
-    [items setObject: options[@"appId"] forKey: @"com.facebook.sharedSticker.appID"];
-
-    if(![options[@"backgroundImage"] isEqual:[NSNull null]] && options[@"backgroundImage"] != nil) {
-        NSURL *backgroundImageURL = [RCTConvert NSURL:options[@"backgroundImage"]];
-        UIImage *image = [UIImage imageWithData: [NSData dataWithContentsOfURL:backgroundImageURL]];
-        [items setObject: UIImagePNGRepresentation(image) forKey: @"com.facebook.sharedSticker.backgroundImage"];
-    }
-
-    if(![options[@"stickerImage"] isEqual:[NSNull null]] && options[@"stickerImage"] != nil) {
-        NSURL *stickerImageURL = [RCTConvert NSURL:options[@"stickerImage"]];
-        UIImage *image = [UIImage imageWithData: [NSData dataWithContentsOfURL: stickerImageURL]];
-        [items setObject: UIImagePNGRepresentation(image) forKey: @"com.facebook.sharedSticker.stickerImage"];
-    }
-
-    if(![options[@"backgroundVideo"] isEqual:[NSNull null]] && options[@"backgroundVideo"] != nil) {
-        NSURL *backgroundVideoURL = [RCTConvert NSURL:options[@"backgroundVideo"]];
-        NSData *video = [NSData dataWithContentsOfURL:backgroundVideoURL];
-        [items setObject: video forKey: @"com.facebook.sharedSticker.backgroundVideo"];
-    }
-
-    if(![options[@"attributionURL"] isEqual:[NSNull null]] && options[@"attributionURL"] != nil) {
-        NSString *attrURL = [RCTConvert NSString:options[@"attributionURL"]];
-        [items setObject: attrURL forKey: @"com.facebook.sharedSticker.contentURL"];
-    }
-
-    NSString *backgroundTopColor;
-     if(![options[@"backgroundTopColor"] isEqual:[NSNull null]] && options[@"backgroundTopColor"] != nil) {
-        backgroundTopColor = [RCTConvert NSString:options[@"backgroundTopColor"]];
-    } else {
-        backgroundTopColor = @"#906df4";
-    }
-    [items setObject: backgroundTopColor forKey: @"com.facebook.sharedSticker.backgroundTopColor"];
-
-    NSString *backgroundBottomColor;
-    if(![options[@"backgroundBottomColor"] isEqual:[NSNull null]] && options[@"backgroundBottomColor"] != nil) {
-        backgroundBottomColor = [RCTConvert NSString:options[@"backgroundBottomColor"]];
-    } else {
-        backgroundBottomColor = @"#837DF4";
-    }
-    [items setObject: backgroundBottomColor forKey: @"com.facebook.sharedSticker.backgroundBottomColor"];
-
-    // Putting dictionary of options inside an array
-    NSArray *pasteboardItems = @[items];
-
-    // Prepare options to facebook
-    NSDictionary *pasteboardOptions = @{UIPasteboardOptionExpirationDate : [[NSDate date] dateByAddingTimeInterval:60 * 5]};
-
-    // This call is iOS 10+, can use 'setItems' depending on what versions you support
-    [[UIPasteboard generalPasteboard] setItems:pasteboardItems options:pasteboardOptions];
-    [[UIApplication sharedApplication] openURL:urlScheme options:@{} completionHandler:nil];
-
-    resolve(@[@true, @""]);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (![[UIApplication sharedApplication] canOpenURL:urlScheme]) {
+                reject(@"EUNAVAILABLE", @"Facebook Stories is no longer available", nil);
+                return;
+            }
+            NSDictionary *pasteboardOptions = @{UIPasteboardOptionExpirationDate: [NSDate.date dateByAddingTimeInterval:60 * 5]};
+            [[UIPasteboard generalPasteboard] setItems:@[items] options:pasteboardOptions];
+            [[UIApplication sharedApplication] openURL:urlScheme options:@{} completionHandler:^(BOOL success) {
+                if (success) {
+                    resolve(@[@true, @""]);
+                } else {
+                    reject(@"EUNAVAILABLE", @"Unable to open Facebook Stories", nil);
+                }
+            }];
+        });
+    });
 }
 
-- (NSError*)fallbackFacebook {
-    // Cannot open facebook
-    NSString *stringURL = @"https://itunes.apple.com/app/facebook/id284882215";
-    NSURL *url = [NSURL URLWithString:stringURL];
-    [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
-
-    NSString *errorMessage = @"Not installed";
-    NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};
-    NSError *error = [NSError errorWithDomain:@"com.rnshare" code:1 userInfo:userInfo];
-
-    NSLog(errorMessage);
-    return error;
+- (NSError *)fallbackFacebook {
+    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://itunes.apple.com/app/facebook/id284882215"] options:@{} completionHandler:nil];
+    return [NSError errorWithDomain:@"com.rnshare" code:1 userInfo:@{NSLocalizedFailureReasonErrorKey: @"Not installed"}];
 }
 @end

--- a/ios/GenericShare.m
+++ b/ios/GenericShare.m
@@ -7,6 +7,7 @@
 //
 
 #import "GenericShare.h"
+#import "RNShareUtils.h"
 
 @implementation GenericShare
     RCT_EXPORT_MODULE();
@@ -16,38 +17,47 @@
     serviceType:(NSString*)serviceType
     inAppBaseUrl:(NSString *)inAppBaseUrl {
 
-    NSLog(@"Try open view");
+    NSString *message = [RCTConvert NSString:options[@"message"]] ?: @"";
+    NSURL *URL = [RCTConvert NSURL:options[@"url"]];
+    if (message.length == 0 && !URL) {
+        reject(@"EINVAL", @"A message or URL is required", nil);
+        return;
+    }
     if([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:inAppBaseUrl]]) {
-        SLComposeViewController *composeController = [SLComposeViewController  composeViewControllerForServiceType:serviceType];
-
-        NSURL *URL = [RCTConvert NSURL:options[@"url"]];
-        if (URL) {
-            if (URL.fileURL || [URL.scheme.lowercaseString isEqualToString:@"data"]) {
-                NSError *error;
-                NSData *data = [NSData dataWithContentsOfURL:URL
-                                                     options:(NSDataReadingOptions)0
-                                                       error:&error];
-                if (!data) {
-                    reject(@"no data",@"no data",error);
-                    return;
-                }
-                UIImage *image = [UIImage imageWithData: data];
-                [composeController addImage:image];
-
-            } else {
-                [composeController addURL:URL];
+        BOOL isImage = URL.fileURL || [URL.scheme.lowercaseString isEqualToString:@"data"];
+        void (^present)(UIImage *) = ^(UIImage *image) {
+            UIViewController *ctrl = RCTPresentedViewController();
+            SLComposeViewController *composeController = [SLComposeViewController composeViewControllerForServiceType:serviceType];
+            if (!ctrl || !composeController) {
+                reject(@"EUNAVAILABLE", @"Unable to present share composer", nil);
+                return;
             }
+            if ((isImage && ![composeController addImage:image]) ||
+                (!isImage && URL && ![composeController addURL:URL]) ||
+                (message.length > 0 && ![composeController setInitialText:message])) {
+                reject(@"EINVAL", @"Unable to add content to share composer", nil);
+                return;
+            }
+            [ctrl presentViewController:composeController animated:YES completion:^{
+                resolve(@[@true, @""]);
+            }];
+        };
+        if (isImage) {
+            dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+                NSError *error = nil;
+                NSData *data = [NSData dataWithContentsOfURL:URL options:0 error:&error];
+                UIImage *image = data ? [UIImage imageWithData:data] : nil;
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    if (!image) {
+                        reject(@"EINVAL", @"Unable to read shared image", error);
+                        return;
+                    }
+                    present(image);
+                });
+            });
+        } else {
+            present(nil);
         }
-
-        if ([options objectForKey:@"message"] && [options objectForKey:@"message"] != [NSNull null]) {
-            NSString *text = [RCTConvert NSString:options[@"message"]];
-            [composeController setInitialText:text];
-        }
-
-
-        UIViewController *ctrl = RCTPresentedViewController();
-        [ctrl presentViewController:composeController animated:YES completion:Nil];
-        resolve(@[@true, @""]);
       } else {
         NSString *errorMessage = @"Not installed";
         NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};
@@ -56,16 +66,19 @@
         NSLog(@"%@", errorMessage);
           reject(@"com.rnshare",@"Not installed",error);
 
-        NSString *escapedString = [options[@"message"] stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
+        NSString *url = [RCTConvert NSString:options[@"url"]] ?: @"";
 
         if ([options[@"social"] isEqualToString:@"twitter"]) {
-          NSString *URL = [NSString stringWithFormat:@"https://twitter.com/intent/tweet?text=%@&url=%@", escapedString, options[@"url"]];
-          [self openScheme:URL];
+          NSURL *URL = [RNShareUtils URLWithString:@"https://twitter.com/intent/tweet" queryItems:@[
+              [NSURLQueryItem queryItemWithName:@"text" value:message],
+              [NSURLQueryItem queryItemWithName:@"url" value:url]
+          ]];
+          [self openScheme:URL.absoluteString];
         }
 
         if ([options[@"social"] isEqualToString:@"facebook"]) {
-          NSString *URL = [NSString stringWithFormat:@"https://www.facebook.com/sharer/sharer.php?u=%@", options[@"url"]];
-          [self openScheme:URL];
+          NSURL *URL = [RNShareUtils URLWithString:@"https://www.facebook.com/sharer/sharer.php" queryItems:@[[NSURLQueryItem queryItemWithName:@"u" value:url]]];
+          [self openScheme:URL.absoluteString];
         }
 
       }
@@ -78,7 +91,6 @@
           if (@available(iOS 10.0, *)) {
               [application openURL:schemeURL options:@{} completionHandler:nil];
           }
-          NSLog(@"Open %@", schemeURL);
       }
 
   }

--- a/ios/GooglePlusShare.m
+++ b/ios/GooglePlusShare.m
@@ -7,6 +7,7 @@
 //
 
 #import "GooglePlusShare.h"
+#import "RNShareUtils.h"
 
 @implementation GooglePlusShare
     RCT_EXPORT_MODULE();
@@ -14,25 +15,30 @@
     reject:(RCTPromiseRejectBlock)reject
     resolve:(RCTPromiseResolveBlock)resolve {
 
-    NSLog(@"Try open view");
-
-    if ([options objectForKey:@"url"] && [options objectForKey:@"url"] != [NSNull null]) {
-        NSString *url = [NSString stringWithFormat:@"https://plus.google.com/share?url=%@", options[@"url"]];
-        NSURL *gplusURL = [NSURL URLWithString:[url stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+        NSString *link = [RCTConvert NSString:options[@"url"]];
+        if (link.length == 0) {
+            reject(@"EINVAL", @"A URL is required", nil);
+            return;
+        }
+        NSURL *gplusURL = [RNShareUtils URLWithString:@"https://plus.google.com/share" queryItems:@[[NSURLQueryItem queryItemWithName:@"url" value:link]]];
 
         if ([[UIApplication sharedApplication] canOpenURL: gplusURL]) {
-            [[UIApplication sharedApplication] openURL:gplusURL options:@{} completionHandler:nil];
-            resolve(@[@true, @""]);
+            [[UIApplication sharedApplication] openURL:gplusURL options:@{} completionHandler:^(BOOL success) {
+                if (success) {
+                    resolve(@[@true, @""]);
+                } else {
+                    reject(@"EUNAVAILABLE", @"Unable to open share target", nil);
+                }
+            }];
         } else {
             // Cannot open gplus
             NSString *errorMessage = @"Not installed";
             NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};
             NSError *error = [NSError errorWithDomain:@"com.rnshare" code:1 userInfo:userInfo];
 
-            NSLog(errorMessage);
+            NSLog(@"%@", errorMessage);
             reject(@"com.rnshare",errorMessage,error);
         }
-    }
 }
 
 

--- a/ios/InstagramShare.m
+++ b/ios/InstagramShare.m
@@ -6,156 +6,126 @@
 //
 
 #import "InstagramShare.h"
-#import <AVFoundation/AVFoundation.h>
-@import Photos;
+#import "RNShareUtils.h"
+#import <Photos/Photos.h>
 
 @implementation InstagramShare
-    RCT_EXPORT_MODULE();
+RCT_EXPORT_MODULE();
+
 - (void)shareSingle:(NSDictionary *)options
-    reject:(RCTPromiseRejectBlock)reject
-    resolve:(RCTPromiseResolveBlock)resolve {
-
-    NSLog(@"Try open view");
-
-    NSURL * shareURL;
-    float videoDurationSeconds = 0.0f;
-    NSString* url = options[@"url"];
-    if (url) {
-        NSURL * fileURL = [NSURL URLWithString: options[@"url"]];
-        AVURLAsset* videoAsset = [AVURLAsset URLAssetWithURL:fileURL options:nil];
-        CMTime videoDuration = videoAsset.duration;
-        float videoDurationSeconds = CMTimeGetSeconds(videoDuration);
-
-        NSLog(@"Video duration: %f seconds for file %@", videoDurationSeconds, videoAsset.URL.absoluteString);
+            reject:(RCTPromiseRejectBlock)reject
+           resolve:(RCTPromiseResolveBlock)resolve {
+    NSString *url = [RCTConvert NSString:options[@"url"]];
+    NSURL *shareURL;
+    if (url.length > 0) {
+        NSString *identifier = [url hasPrefix:@"ph://"] ? [url substringFromIndex:5] : url;
+        shareURL = [RNShareUtils URLWithString:@"instagram://library" queryItems:@[[NSURLQueryItem queryItemWithName:@"LocalIdentifier" value:identifier]]];
     } else {
-        //this will send message directly to instagram DM with plain text
-        shareURL = [NSURL URLWithString:[NSString stringWithFormat:@"instagram://sharesheet?text=%@", options[@"message"]]];
+        NSString *message = [RCTConvert NSString:options[@"message"]];
+        if (message.length == 0) {
+            reject(@"EINVAL", @"A message or URL is required", nil);
+            return;
+        }
+        shareURL = [RNShareUtils URLWithString:@"instagram://sharesheet" queryItems:@[[NSURLQueryItem queryItemWithName:@"text" value:message]]];
     }
-
-    if (shareURL) {
-        NSLog(@"url is already available, no need to do anything");
-    } else if (videoDurationSeconds <= 60.0f) {
-        // Instagram doesn't allow sharing videos longer than 60 seconds on iOS anymore. (next button is not responding, trim is unavailable)
-        NSString *phIdentifier= [options[@"url"] stringByReplacingOccurrencesOfString:@"ph://" withString:@""];
-        NSString * urlString = [NSString stringWithFormat:@"instagram://library?LocalIdentifier=%@", phIdentifier];
-        shareURL = [NSURL URLWithString:urlString];
-    } else {
-        shareURL = [NSURL URLWithString:@"instagram://camera"];
-    }
-
-    if ([[UIApplication sharedApplication] canOpenURL: shareURL]) {
-        [[UIApplication sharedApplication] openURL:shareURL options:@{} completionHandler:nil];
-        resolve(@[@true, @""]);
-    } else {
-        // Cannot open instagram
-        NSString *stringURL = @"https://itunes.apple.com/app/instagram/id389801252";
-        NSURL *url = [NSURL URLWithString:stringURL];
-
-        [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:^(BOOL success) {}];
-
-        NSString *errorMessage = @"Not installed";
-        NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};
-        NSError *error = [NSError errorWithDomain:@"com.rnshare" code:1 userInfo:userInfo];
-
-        NSLog(@"%@", errorMessage);
-        reject(@"com.rnshare",@"Not installed",error);
-    }
+    [self openInstagramURL:shareURL reject:reject resolve:resolve];
 }
 
-- (void)shareSingleImage:(NSDictionary *)options
-         reject:(RCTPromiseRejectBlock)reject
-         resolve:(RCTPromiseResolveBlock)resolve {
-
-    UIImage *image;
-    NSURL *imageURL = [RCTConvert NSURL:options[@"url"]];
-    if (imageURL) {
-        if (imageURL.fileURL || [imageURL.scheme.lowercaseString isEqualToString:@"data"]) {
-            NSError *error;
-            NSData *data = [NSData dataWithContentsOfURL:imageURL
-                                                 options:(NSDataReadingOptions)0
-                                                   error:&error];
-            if (!data) {
-                reject(@"com.rnshare",@"no data",error);
-                return;
-            }
-            image = [UIImage imageWithData: data];
-            [self savePictureAndOpenInstagram: image
-                              reject: reject
-                              resolve: resolve];
-        }
-    } else {
-        [[UIApplication sharedApplication] openURL: [NSURL URLWithString:@"instagram://camera"] options:@{} completionHandler:nil];
-        resolve(@[@true, @""]);
-    }
-}
-
--(void)savePictureAndOpenInstagram:(UIImage *)base64Image
-                   reject:(RCTPromiseRejectBlock)reject
-                   resolve:(RCTPromiseResolveBlock)resolve {
-
-    // Check for photo library permissions
-    PHAuthorizationStatus status = [PHPhotoLibrary authorizationStatus];
-    if (status == PHAuthorizationStatusNotDetermined) {
-        [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus newStatus) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                if (newStatus == PHAuthorizationStatusAuthorized) {
-                    [self savePictureAndOpenInstagram:base64Image reject:reject resolve:resolve];
-                } else {
-                    if (reject != NULL) {
-                        reject(@"com.rnshare", @"Photo library access denied by user", nil);
-                    }
-                }
-            });
-        }];
-        return;
-    } else if (status != PHAuthorizationStatusAuthorized) {
-
-        if (reject != NULL) {
-            reject(@"com.rnshare", @"Photo library access not authorized", nil);
-        }
+- (void)openInstagramURL:(NSURL *)URL
+                 reject:(RCTPromiseRejectBlock)reject
+                resolve:(RCTPromiseResolveBlock)resolve {
+    if (![[UIApplication sharedApplication] canOpenURL:URL]) {
+        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://itunes.apple.com/app/instagram/id389801252"] options:@{} completionHandler:nil];
+        reject(@"com.rnshare", @"Not installed", nil);
         return;
     }
-
-    NSURL *URL = [self fileURLWithTemporaryImageData:UIImageJPEGRepresentation(base64Image, 0.9)];
-    __block PHAssetChangeRequest *_mChangeRequest = nil;
-    __block PHObjectPlaceholder *placeholder;
-
-    [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
-
-        NSData *pngData = [NSData dataWithContentsOfURL:URL];
-        UIImage *image = [UIImage imageWithData:pngData];
-        _mChangeRequest = [PHAssetChangeRequest creationRequestForAssetFromImage:image];
-        placeholder = _mChangeRequest.placeholderForCreatedAsset;
-    } completionHandler:^(BOOL success, NSError *error) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            if (success) {
-                NSURL *instagramURL = [NSURL URLWithString:[NSString stringWithFormat:@"instagram://library?LocalIdentifier=\%@", [placeholder localIdentifier]]];
-
-                if ([[UIApplication sharedApplication] canOpenURL:instagramURL]) {
-                    if (@available(iOS 10.0, *)) {
-                        [[UIApplication sharedApplication] openURL:instagramURL options:@{} completionHandler:NULL];
-                    }
-                    if (resolve != NULL) {
-                        resolve(@[@true, @""]);
-                    }
-                }
-            }
-            else {
-                //Error while writing
-                if (reject != NULL) {
-                    reject(@"com.rnshare",@"error",error);
-                }
-            }
-        });
+    [[UIApplication sharedApplication] openURL:URL options:@{} completionHandler:^(BOOL success) {
+        if (success) {
+            resolve(@[@true, @""]);
+        } else {
+            reject(@"EUNAVAILABLE", @"Unable to open Instagram", nil);
+        }
     }];
 }
 
-- (NSURL *)fileURLWithTemporaryImageData:(NSData *)data {
-    NSString *writePath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"instagram.ig"];
-    if (![data writeToFile:writePath atomically:YES]) {
-        return nil;
+- (void)shareSingleImage:(NSDictionary *)options
+                 reject:(RCTPromiseRejectBlock)reject
+                resolve:(RCTPromiseResolveBlock)resolve {
+    NSURL *imageURL = [RCTConvert NSURL:options[@"url"]];
+    if (!imageURL) {
+        [self openInstagramURL:[NSURL URLWithString:@"instagram://camera"] reject:reject resolve:resolve];
+        return;
     }
-    return [NSURL fileURLWithPath:writePath];
+    if (!imageURL.isFileURL && ![imageURL.scheme.lowercaseString isEqualToString:@"data"]) {
+        reject(@"EINVAL", @"Instagram images must use a file or data URL", nil);
+        return;
+    }
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        NSError *error;
+        NSData *data = [NSData dataWithContentsOfURL:imageURL options:0 error:&error];
+        UIImage *image = data ? [UIImage imageWithData:data] : nil;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (!image) {
+                reject(@"com.rnshare", @"Unable to decode image", error);
+                return;
+            }
+            [self savePictureAndOpenInstagram:image reject:reject resolve:resolve];
+        });
+    });
+}
+
+- (void)savePictureAndOpenInstagram:(UIImage *)image
+                            reject:(RCTPromiseRejectBlock)reject
+                           resolve:(RCTPromiseResolveBlock)resolve {
+    if (!image) {
+        reject(@"com.rnshare", @"Unable to decode image", nil);
+        return;
+    }
+    if (![[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:@"instagram://library"]]) {
+        reject(@"com.rnshare", @"Not installed", nil);
+        return;
+    }
+
+    PHAuthorizationStatus status;
+    if (@available(iOS 14.0, *)) {
+        status = [PHPhotoLibrary authorizationStatusForAccessLevel:PHAccessLevelReadWrite];
+    } else {
+        status = [PHPhotoLibrary authorizationStatus];
+    }
+    if (status == PHAuthorizationStatusNotDetermined) {
+        void (^completion)(PHAuthorizationStatus) = ^(__unused PHAuthorizationStatus newStatus) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self savePictureAndOpenInstagram:image reject:reject resolve:resolve];
+            });
+        };
+        if (@available(iOS 14.0, *)) {
+            [PHPhotoLibrary requestAuthorizationForAccessLevel:PHAccessLevelReadWrite handler:completion];
+        } else {
+            [PHPhotoLibrary requestAuthorization:completion];
+        }
+        return;
+    }
+    BOOL authorized = status == PHAuthorizationStatusAuthorized;
+    if (@available(iOS 14.0, *)) authorized = authorized || status == PHAuthorizationStatusLimited;
+    if (!authorized) {
+        reject(@"com.rnshare", @"Photo library access not authorized", nil);
+        return;
+    }
+
+    __block NSString *identifier;
+    [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
+        PHAssetChangeRequest *request = [PHAssetChangeRequest creationRequestForAssetFromImage:image];
+        identifier = request.placeholderForCreatedAsset.localIdentifier;
+    } completionHandler:^(BOOL success, NSError *error) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (!success || identifier.length == 0) {
+                reject(@"com.rnshare", @"Unable to save image to Photos", error);
+                return;
+            }
+            NSURL *URL = [RNShareUtils URLWithString:@"instagram://library" queryItems:@[[NSURLQueryItem queryItemWithName:@"LocalIdentifier" value:identifier]]];
+            [self openInstagramURL:URL reject:reject resolve:resolve];
+        });
+    }];
 }
 
 @end

--- a/ios/InstagramStories.h
+++ b/ios/InstagramStories.h
@@ -19,5 +19,5 @@
 #import <React/RCTUtils.h>
 @interface InstagramStories : NSObject <RCTBridgeModule>
 
-- (void *) shareSingle:(NSDictionary *)options reject:(RCTPromiseRejectBlock)reject resolve:(RCTPromiseResolveBlock)resolve;
+- (void) shareSingle:(NSDictionary *)options reject:(RCTPromiseRejectBlock)reject resolve:(RCTPromiseResolveBlock)resolve;
 @end

--- a/ios/InstagramStories.m
+++ b/ios/InstagramStories.m
@@ -6,155 +6,128 @@
 //  link: https://github.com/loga4
 //
 
-// import RCTLog
-#import <React/RCTLog.h>
-#import <Photos/Photos.h>
-
 #import "InstagramStories.h"
+#import "RNShareUtils.h"
+#import <Photos/Photos.h>
 
 @implementation InstagramStories
 RCT_EXPORT_MODULE();
 
-- (void)openInstagramWithItems:(NSDictionary *)items urlScheme:(NSURL *)urlScheme resolve:(RCTPromiseResolveBlock)resolve {
-    // Putting dictionary of options inside an array
-    NSArray *pasteboardItems = @[items];
-    NSDictionary *pasteboardOptions = @{UIPasteboardOptionExpirationDate : [[NSDate date] dateByAddingTimeInterval:60 * 5]};
-
-    [[UIPasteboard generalPasteboard] setItems:pasteboardItems options:pasteboardOptions];
-    [[UIApplication sharedApplication] openURL:urlScheme options:@{} completionHandler:nil];
-
-    resolve(@[@true, @""]);
+- (void)openInstagramWithItems:(NSDictionary *)items
+                    urlScheme:(NSURL *)urlScheme
+                       reject:(RCTPromiseRejectBlock)reject
+                      resolve:(RCTPromiseResolveBlock)resolve {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (![[UIApplication sharedApplication] canOpenURL:urlScheme]) {
+            reject(@"EUNAVAILABLE", @"Instagram Stories is no longer available", nil);
+            return;
+        }
+        NSDictionary *pasteboardOptions = @{UIPasteboardOptionExpirationDate: [NSDate.date dateByAddingTimeInterval:60 * 5]};
+        [[UIPasteboard generalPasteboard] setItems:@[items] options:pasteboardOptions];
+        [[UIApplication sharedApplication] openURL:urlScheme options:@{} completionHandler:^(BOOL success) {
+            if (success) {
+                resolve(@[@true, @""]);
+            } else {
+                reject(@"EUNAVAILABLE", @"Unable to open Instagram Stories", nil);
+            }
+        }];
+    });
 }
 
 - (void)shareSingle:(NSDictionary *)options
-    reject:(RCTPromiseRejectBlock)reject
-    resolve:(RCTPromiseResolveBlock)resolve {
-
-    NSURL *urlScheme = [NSURL URLWithString:[NSString stringWithFormat:@"instagram-stories://share?source_application=%@", options[@"appId"]]];
-
-    // Create dictionary of assets and attribution
-    NSMutableDictionary *items = [NSMutableDictionary dictionary];
-
-    if(![options[@"backgroundImage"] isEqual:[NSNull null]] && options[@"backgroundImage"] != nil) {
-        NSURL *backgroundImageURL = [RCTConvert NSURL:options[@"backgroundImage"]];
-        UIImage *image = [UIImage imageWithData: [NSData dataWithContentsOfURL:backgroundImageURL]];
-        [items setObject: UIImagePNGRepresentation(image) forKey: @"com.instagram.sharedSticker.backgroundImage"];
+            reject:(RCTPromiseRejectBlock)reject
+           resolve:(RCTPromiseResolveBlock)resolve {
+    NSString *appId = [RCTConvert NSString:options[@"appId"]];
+    if (appId.length == 0) {
+        reject(@"EINVAL", @"An appId is required", nil);
+        return;
+    }
+    NSURL *urlScheme = [RNShareUtils URLWithString:@"instagram-stories://share" queryItems:@[[NSURLQueryItem queryItemWithName:@"source_application" value:appId]]];
+    if (![[UIApplication sharedApplication] canOpenURL:urlScheme]) {
+        reject(@"cannot open URL", @"cannot open URL", [self fallbackInstagram]);
+        return;
     }
 
-    if(![options[@"stickerImage"] isEqual:[NSNull null]] && options[@"stickerImage"] != nil) {
-        NSURL *stickerImageURL = [RCTConvert NSURL:options[@"stickerImage"]];
-        UIImage *image = [UIImage imageWithData: [NSData dataWithContentsOfURL: stickerImageURL]];
-        [items setObject: UIImagePNGRepresentation(image) forKey: @"com.instagram.sharedSticker.stickerImage"];
-    }
-
-    if(![options[@"attributionURL"] isEqual:[NSNull null]] && options[@"attributionURL"] != nil) {
-        NSString *attrURL = [RCTConvert NSString:options[@"attributionURL"]];
-        [items setObject: attrURL forKey: @"com.instagram.sharedSticker.contentURL"];
-    }
-
-    NSString *backgroundTopColor;
-     if(![options[@"backgroundTopColor"] isEqual:[NSNull null]] && options[@"backgroundTopColor"] != nil) {
-        backgroundTopColor = [RCTConvert NSString:options[@"backgroundTopColor"]];
-    } else {
-        backgroundTopColor = @"#906df4";
-    }
-    [items setObject: backgroundTopColor forKey: @"com.instagram.sharedSticker.backgroundTopColor"];
-
-    NSString *backgroundBottomColor;
-    if(![options[@"backgroundBottomColor"] isEqual:[NSNull null]] && options[@"backgroundBottomColor"] != nil) {
-        backgroundBottomColor = [RCTConvert NSString:options[@"backgroundBottomColor"]];
-    } else {
-        backgroundBottomColor = @"#837DF4";
-    }
-    [items setObject: backgroundBottomColor forKey: @"com.instagram.sharedSticker.backgroundBottomColor"];
-
-    if(![options[@"linkUrl"] isEqual:[NSNull null]] && options[@"linkUrl"] != nil) {
-        NSString *linkURL = [RCTConvert NSString:options[@"linkUrl"]];
-        [items setObject: linkURL forKey: @"com.instagram.sharedSticker.linkURL"];
-    }
-
-    if(![options[@"linkText"] isEqual:[NSNull null]] && options[@"linkText"] != nil) {
-        NSString *linkText = [RCTConvert NSString:options[@"linkText"]];
-        [items setObject: linkText forKey: @"com.instagram.sharedSticker.linkText"];
-    }
-
-    if(![options[@"backgroundVideo"] isEqual:[NSNull null]] && options[@"backgroundVideo"] != nil) {
-        NSURL *backgroundVideoURL = [RCTConvert NSURL:options[@"backgroundVideo"]];
-
-        if ([backgroundVideoURL.scheme isEqualToString:@"file"]) {
-            // Handle local file
-            NSData *videoData = [NSData dataWithContentsOfURL:backgroundVideoURL];
-            if (videoData) {
-                [items setObject:videoData forKey:@"com.instagram.sharedSticker.backgroundVideo"];
-                [self openInstagramWithItems:items urlScheme:urlScheme resolve:resolve];
-            } else {
-                NSLog(@"Failed to read local video file");
-                [self openInstagramWithItems:items urlScheme:urlScheme resolve:resolve];
+    RCTPromiseRejectBlock rejectOnMain = ^(NSString *code, NSString *message, NSError *error) {
+        dispatch_async(dispatch_get_main_queue(), ^{ reject(code, message, error); });
+    };
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        NSMutableDictionary *items = [NSMutableDictionary dictionary];
+        for (NSString *key in @[@"backgroundImage", @"stickerImage"]) {
+            NSString *path = [RCTConvert NSString:options[key]];
+            if (path != nil) {
+                NSURL *URL = [RCTConvert NSURL:path];
+                NSData *data = URL ? [NSData dataWithContentsOfURL:URL] : nil;
+                UIImage *image = data ? [UIImage imageWithData:data] : nil;
+                NSData *png = image ? UIImagePNGRepresentation(image) : nil;
+                if (!png) {
+                    rejectOnMain(@"EINVAL", [NSString stringWithFormat:@"Unable to decode %@", key], nil);
+                    return;
+                }
+                items[[@"com.instagram.sharedSticker." stringByAppendingString:key]] = png;
             }
-        } else {
-            NSString *urlString = backgroundVideoURL.absoluteString;
-            NSURLComponents *components = [[NSURLComponents alloc] initWithString:urlString];
-            NSString *assetId = nil;
+        }
+        NSDictionary *keys = @{@"attributionURL": @"contentURL", @"linkUrl": @"linkURL", @"linkText": @"linkText"};
+        for (NSString *key in keys) {
+            NSString *value = [RCTConvert NSString:options[key]];
+            if (value != nil) items[[@"com.instagram.sharedSticker." stringByAppendingString:keys[key]]] = value;
+        }
+        items[@"com.instagram.sharedSticker.backgroundTopColor"] = [RCTConvert NSString:options[@"backgroundTopColor"]] ?: @"#906df4";
+        items[@"com.instagram.sharedSticker.backgroundBottomColor"] = [RCTConvert NSString:options[@"backgroundBottomColor"]] ?: @"#837DF4";
 
-            // Get asset ID from URL
+        NSString *video = [RCTConvert NSString:options[@"backgroundVideo"]];
+        if (video == nil) {
+            [self openInstagramWithItems:items urlScheme:urlScheme reject:rejectOnMain resolve:resolve];
+            return;
+        }
+        NSURL *videoURL = [RCTConvert NSURL:video];
+        if (videoURL.isFileURL || [videoURL.scheme.lowercaseString isEqualToString:@"data"]) {
+            NSData *data = [NSData dataWithContentsOfURL:videoURL];
+            if (!data) {
+                rejectOnMain(@"EINVAL", @"Unable to read background video", nil);
+                return;
+            }
+            items[@"com.instagram.sharedSticker.backgroundVideo"] = data;
+            [self openInstagramWithItems:items urlScheme:urlScheme reject:rejectOnMain resolve:resolve];
+            return;
+        }
+
+        NSString *assetId = [video hasPrefix:@"ph://"] ? [video substringFromIndex:5] : nil;
+        if (assetId == nil) {
+            NSURLComponents *components = [NSURLComponents componentsWithString:video];
             for (NSURLQueryItem *item in components.queryItems) {
                 if ([item.name isEqualToString:@"id"]) {
                     assetId = item.value;
                     break;
                 }
             }
-
-            if (assetId) {
-                // Fetch the asset
-                PHFetchResult *fetchResult = [PHAsset fetchAssetsWithLocalIdentifiers:@[assetId] options:nil];
-                PHAsset *asset = fetchResult.firstObject;
-
-                if (asset) {
-                    PHVideoRequestOptions *options = [[PHVideoRequestOptions alloc] init];
-                    options.networkAccessAllowed = YES;
-                    options.deliveryMode = PHVideoRequestOptionsDeliveryModeHighQualityFormat;
-
-                    [[PHImageManager defaultManager] requestAVAssetForVideo:asset
-                                                                    options:options
-                                                            resultHandler:^(AVAsset * _Nullable avAsset, AVAudioMix * _Nullable audioMix, NSDictionary * _Nullable info) {
-                        if ([avAsset isKindOfClass:[AVURLAsset class]]) {
-                            AVURLAsset *urlAsset = (AVURLAsset *)avAsset;
-                            NSData *video = [NSData dataWithContentsOfURL:urlAsset.URL];
-
-                            dispatch_async(dispatch_get_main_queue(), ^{
-                                if (video) {
-                                    [items setObject:video forKey:@"com.instagram.sharedSticker.backgroundVideo"];
-                                    [self openInstagramWithItems:items urlScheme:urlScheme resolve:resolve];
-                                } else {
-                                    NSLog(@"Failed to convert video asset to NSData");
-                                    [self openInstagramWithItems:items urlScheme:urlScheme resolve:resolve];
-                                }
-                            });
-                        }
-                    }];
-                } else {
-                    NSLog(@"Could not find asset with ID: %@", assetId);
-                    [self openInstagramWithItems:items urlScheme:urlScheme resolve:resolve];
-                }
-            }
         }
-    } else {
-        [self openInstagramWithItems:items urlScheme:urlScheme resolve:resolve];
-    }
+        if (assetId.length == 0) {
+            rejectOnMain(@"EINVAL", @"Background video has no Photos asset identifier", nil);
+            return;
+        }
+        PHAsset *asset = [PHAsset fetchAssetsWithLocalIdentifiers:@[assetId] options:nil].firstObject;
+        if (!asset) {
+            rejectOnMain(@"EINVAL", @"Background video asset was not found", nil);
+            return;
+        }
+        PHVideoRequestOptions *requestOptions = [[PHVideoRequestOptions alloc] init];
+        requestOptions.networkAccessAllowed = YES;
+        requestOptions.deliveryMode = PHVideoRequestOptionsDeliveryModeHighQualityFormat;
+        [[PHImageManager defaultManager] requestAVAssetForVideo:asset options:requestOptions resultHandler:^(AVAsset *avAsset, AVAudioMix *audioMix, NSDictionary *info) {
+            NSData *data = [avAsset isKindOfClass:AVURLAsset.class] ? [NSData dataWithContentsOfURL:((AVURLAsset *)avAsset).URL] : nil;
+            if (!data) {
+                rejectOnMain(@"EINVAL", @"Unable to load background video asset", nil);
+                return;
+            }
+            items[@"com.instagram.sharedSticker.backgroundVideo"] = data;
+            [self openInstagramWithItems:items urlScheme:urlScheme reject:rejectOnMain resolve:resolve];
+        }];
+    });
 }
 
-- (NSError*)fallbackInstagram {
-    // Cannot open instagram
-    NSString *stringURL = @"https://itunes.apple.com/app/instagram/id389801252";
-    NSURL *url = [NSURL URLWithString:stringURL];
-    [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
-
-    NSString *errorMessage = @"Not installed";
-    NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};
-    NSError *error = [NSError errorWithDomain:@"com.rnshare" code:1 userInfo:userInfo];
-
-    NSLog(errorMessage);
-    return error;
+- (NSError *)fallbackInstagram {
+    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://itunes.apple.com/app/instagram/id389801252"] options:@{} completionHandler:nil];
+    return [NSError errorWithDomain:@"com.rnshare" code:1 userInfo:@{NSLocalizedFailureReasonErrorKey: @"Not installed"}];
 }
-// https://instagram.fhrk1-1.fna.fbcdn.net/vp/80c479ffc246a9320e614fa4def6a3dc/5C667D3F/t51.12442-15/e35/50679864_1663709050595244_6964601913751831460_n.jpg?_nc_ht=instagram.fhrk1-1.fna.fbcdn.net
 @end

--- a/ios/MessengerShare.m
+++ b/ios/MessengerShare.m
@@ -1,4 +1,5 @@
 #import "MessengerShare.h"
+#import "RNShareUtils.h"
 
 #import <React/RCTConvert.h>
 
@@ -7,15 +8,21 @@ RCT_EXPORT_MODULE();
 
 - (void)shareSingle:(NSDictionary *)options reject:(RCTPromiseRejectBlock)reject resolve:(RCTPromiseResolveBlock)resolve {
 
-  if ([options objectForKey:@"url"] && [options objectForKey:@"url"] != [NSNull null]) {
-
-    NSString *urlString = [NSString stringWithFormat:@"fb-messenger://share?link=%@", [RCTConvert NSString:options[@"url"]]];
-    NSURL *url = [NSURL URLWithString:urlString];
+    NSString *link = [RCTConvert NSString:options[@"url"]];
+    if (link.length == 0) {
+      reject(@"EINVAL", @"A URL is required", nil);
+      return;
+    }
+    NSURL *url = [RNShareUtils URLWithString:@"fb-messenger://share" queryItems:@[[NSURLQueryItem queryItemWithName:@"link" value:link]]];
 
     if ([[UIApplication sharedApplication] canOpenURL:url]) {
-      [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
-
-      resolve(@[@true, @""]);
+      [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:^(BOOL success) {
+        if (success) {
+          resolve(@[@true, @""]);
+        } else {
+          reject(@"EUNAVAILABLE", @"Unable to open share target", nil);
+        }
+      }];
     } else {
       // Cannot open Messenger
       NSString *contentLinkString = @"https://apps.apple.com/us/app/messenger/id454638411";
@@ -29,7 +36,6 @@ RCT_EXPORT_MODULE();
       NSLog(@"%@", errorMessage);
       reject(@"Not installed",@"Not installed",error);
     }
-  }
 }
 
 @end

--- a/ios/RNShare.mm
+++ b/ios/RNShare.mm
@@ -18,7 +18,6 @@
 #import "GooglePlusShare.h"
 #import "EmailShare.h"
 #import "TelegramShare.h"
-#import "TwitterShare.h"
 #import "ViberShare.h"
 #import "MessengerShare.h"
 #import "SmsShare.h"
@@ -30,16 +29,15 @@
 #import "RNShareSpec.h"
 #endif
 
-@implementation RNShare
+@implementation RNShare {
+    RCTPromiseResolveBlock documentPickerResolve;
+    UIDocumentPickerViewController *activeDocumentPicker;
 
-RCTPromiseRejectBlock rejectBlock;
-RCTPromiseResolveBlock resolveBlock;
-
-// we need this since this controller
-// may implement a delegate and could be garbage collected
-// before it is called
-EmailShare *shareCtl;
-SmsShare *smsShareCtl;
+    // Keep delegate-backed adapters alive for this module instance.
+    EmailShare *emailShare;
+    SmsShare *smsShare;
+    WhatsAppShare *whatsAppShare;
+}
 
 - (dispatch_queue_t)methodQueue
 {
@@ -54,8 +52,9 @@ SmsShare *smsShareCtl;
 - (id) init
 {
     if ((self = [super init])) {
-        shareCtl = [[EmailShare alloc] init];
-        smsShareCtl = [[SmsShare alloc] init];
+        emailShare = [[EmailShare alloc] init];
+        smsShare = [[SmsShare alloc] init];
+        whatsAppShare = [[WhatsAppShare alloc] init];
     }
     return self;
 }
@@ -65,19 +64,15 @@ SmsShare *smsShareCtl;
 {
     if (anchorViewTag) {
         UIView *anchorView = [self.bridge.uiManager viewForReactTag:anchorViewTag];
-        return [anchorView convertRect:anchorView.bounds toView:sourceView];
-    } else {
-        return (CGRect){sourceView.center, {1, 1}};
+        if (anchorView) {
+            return [anchorView convertRect:anchorView.bounds toView:sourceView];
+        }
     }
+    return CGRectMake(CGRectGetMidX(sourceView.bounds), CGRectGetMidY(sourceView.bounds), 1, 1);
 }
 
 - (BOOL)isImageMimeType:(NSString *)data {
-    NSRange range = [data rangeOfString:@"data:image" options:NSCaseInsensitiveSearch];
-    if (data && range.location != NSNotFound) {
-        return true;
-    } else {
-        return false;
-    }
+    return data.length >= 11 && [data compare:@"data:image/" options:NSCaseInsensitiveSearch range:NSMakeRange(0, 11)] == NSOrderedSame;
 }
 
 RCT_EXPORT_MODULE()
@@ -122,12 +117,12 @@ RCT_EXPORT_METHOD(shareSingle:(NSDictionary *)options
             [shareCtl shareSingle:options reject: reject resolve: resolve serviceType: SLServiceTypeFacebook inAppBaseUrl:@"fb://"];
         } else if([social isEqualToString:@"facebookstories"]) {
             NSString *appId = [RCTConvert NSString:options[@"appId"]];
-            if (appId) {
+            if (appId.length > 0) {
                 NSLog(@"TRY OPEN FACEBOOK STORIES");
                 FacebookStories *shareCtl = [[FacebookStories alloc] init];
                 [shareCtl shareSingle:options reject: reject resolve: resolve];
             } else {
-                RCTLogError(@"key 'appId' missing in options");
+                reject(@"EINVAL", @"key 'appId' missing in options", nil);
                 return;
             }
         } else if([social isEqualToString:@"twitter"]) {
@@ -140,12 +135,11 @@ RCT_EXPORT_METHOD(shareSingle:(NSDictionary *)options
             [shareCtl shareSingle:options reject: reject resolve: resolve];
         } else if([social isEqualToString:@"whatsapp"]) {
             NSLog(@"TRY OPEN whatsapp");
-            WhatsAppShare *shareCtl = [[WhatsAppShare alloc] init];
-            [shareCtl shareSingle:options reject: reject resolve: resolve];
+            [whatsAppShare shareSingle:options reject: reject resolve: resolve];
         } else if([social isEqualToString:@"instagram"]) {
             NSLog(@"TRY OPEN instagram");
             InstagramShare *shareCtl = [[InstagramShare alloc] init];
-            if([self isImageMimeType:options[@"url"]]) {// Condition to handle image
+            if([self isImageMimeType:[RCTConvert NSString:options[@"url"]]]) {// Condition to handle image
                 [shareCtl shareSingleImage:options reject: reject resolve: resolve];
             } else {
                 [shareCtl shareSingle:options reject: reject resolve: resolve];
@@ -158,13 +152,9 @@ RCT_EXPORT_METHOD(shareSingle:(NSDictionary *)options
             NSLog(@"TRY OPEN telegram");
             TelegramShare *shareCtl = [[TelegramShare alloc] init];
             [shareCtl shareSingle:options reject: reject resolve: resolve];
-        } else if([social isEqualToString:@"twitter"]) {
-            NSLog(@"TRY OPEN twitter");
-            TwitterShare *shareCtl = [[TwitterShare alloc] init];
-            [shareCtl shareSingle:options reject: reject resolve: resolve];
         } else if([social isEqualToString:@"email"]) {
             NSLog(@"TRY OPEN email");
-            [shareCtl shareSingle:options reject: reject resolve: resolve];
+            [emailShare shareSingle:options reject: reject resolve: resolve];
         } else if([social isEqualToString:@"viber"]) {
             NSLog(@"TRY OPEN viber");
             ViberShare *shareCtl = [[ViberShare alloc] init];
@@ -175,14 +165,16 @@ RCT_EXPORT_METHOD(shareSingle:(NSDictionary *)options
             [shareCtl shareSingle:options reject: reject resolve: resolve];
         } else if([social isEqualToString:@"sms"]) {
             NSLog(@"TRY OPEN sms");
-            [smsShareCtl shareSingle:options reject: reject resolve: resolve];
+            [smsShare shareSingle:options reject: reject resolve: resolve];
         } else if([social isEqualToString:@"discord"]) {
             NSLog(@"TRY OPEN discord");
             DiscordShare *shareCtl = [[DiscordShare alloc] init];
             [shareCtl shareSingle:options reject: reject resolve: resolve];
+        } else {
+            reject(@"EINVAL", @"Unsupported social target", nil);
         }
     } else {
-        RCTLogError(@"key 'social' missing in options");
+        reject(@"EINVAL", @"key 'social' missing in options", nil);
         return;
     }
 }
@@ -192,7 +184,7 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options
                   reject:(RCTPromiseRejectBlock)reject)
 {
     if (RCTRunningInAppExtension()) {
-        RCTLogError(@"Unable to show action sheet from app extension");
+        reject(@"EUNAVAILABLE", @"Unable to show action sheet from app extension", nil);
         return;
     }
 
@@ -202,10 +194,14 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options
         [items addObject:message];
     }
     BOOL saveToFiles = [RCTConvert BOOL:options[@"saveToFiles"]];
+    if (saveToFiles && activeDocumentPicker) {
+        reject(@"EINPROGRESS", @"A Files export is already in progress", nil);
+        return;
+    }
     NSString *filename = [RCTConvert NSString:options[@"filename"]];
 
-    NSArray *filenamesArray = options[@"filenames"];
-    NSArray *urlsArray = options[@"urls"];
+    NSArray *filenamesArray = [RCTConvert NSStringArray:options[@"filenames"]];
+    NSArray *urlsArray = [RCTConvert NSArray:options[@"urls"]];
     
     for (int i=0; i<urlsArray.count; i++) {
         NSURL *URL = [RCTConvert NSURL:urlsArray[i]];
@@ -220,30 +216,20 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options
                     return;
                 }
                 
-                //name get from array of filenames
-                @try {
-                    NSString *fileNameByIndex = [RCTConvert NSString:filenamesArray[i]];
-                    if(fileNameByIndex.length>0){
-                        //replace filename with name get by index
-                        filename=fileNameByIndex;
-                    }
-                }
-                @catch (NSException * e) {
-                        RCTLogError(@"Exception get filename from finames array: %@", e);
+                NSString *itemFilename = filename;
+                if (i < filenamesArray.count && [filenamesArray[i] length] > 0) {
+                    itemFilename = filenamesArray[i];
                 }
 
-                if (saveToFiles) {
-
-                    NSURL *filePath = [RNShareUtils getPathFromBase64:URL.absoluteString with:data fileName:filename];
-
-                    if (filePath) {
-                        [items addObject: filePath];
+                if (saveToFiles || itemFilename.length > 0) {
+                    NSURL *filePath = saveToFiles
+                        ? [RNShareUtils getPathFromBase64:URL.absoluteString with:data fileName:itemFilename]
+                        : [RNShareUtils getPathFromFilename:itemFilename with:data];
+                    if (!filePath) {
+                        reject(@"EWRITE", @"Unable to prepare attachment", nil);
+                        return;
                     }
-                } else if (filename.length > 0) {
-                    NSURL *filePath = [RNShareUtils getPathFromFilename:filename with:data];
-                    if (filePath) {
-                        [items addObject: filePath];
-                    }
+                    [items addObject:filePath];
                 } else {
                     [items addObject:data];
                 }
@@ -257,11 +243,15 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options
     BOOL hasActivityItemSources = activityItemSources != nil && activityItemSources.count > 0;
 
     if (items.count == 0 && !hasActivityItemSources) {
-        RCTLogError(@"No `url` or `message` to share");
+        reject(@"EINVAL", @"No `url` or `message` to share", nil);
         return;
     }
 
     UIViewController *controller = RCTPresentedViewController();
+    if (!controller) {
+        reject(@"EUNAVAILABLE", @"No view controller available to present the share sheet", nil);
+        return;
+    }
 
     if (saveToFiles) {
         NSArray *urls = [items filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
@@ -269,18 +259,18 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options
         }]];
 
         if (urls.count == 0) {
-            RCTLogError(@"No `urls` to save in Files");
+            reject(@"EINVAL", @"No `urls` to save in Files", nil);
             return;
         }
         if (@available(iOS 11.0, macCatalyst 13.1, *)) {
-            resolveBlock = resolve;
-            rejectBlock = reject;
             UIDocumentPickerViewController *documentPicker = nil;
             if (@available(iOS 15.0, macCatalyst 15.0, *)) {
                 documentPicker = [[UIDocumentPickerViewController alloc] initForExportingURLs:urls asCopy:YES];
             } else {
                 documentPicker = [[UIDocumentPickerViewController alloc] initWithURLs:urls inMode:UIDocumentPickerModeExportToService];
             }
+            activeDocumentPicker = documentPicker;
+            documentPickerResolve = resolve;
             [documentPicker setDelegate:self];
             [controller presentViewController:documentPicker animated:YES completion:nil];
             return;
@@ -323,19 +313,23 @@ RCT_EXPORT_METHOD(isPackageInstalled:(NSString *)packagename
 }
 
 - (void)documentPickerWasCancelled:(UIDocumentPickerViewController *)controller {
-    if (rejectBlock) {
-        NSError *error = [NSError errorWithDomain:@"CANCELLED" code: 500 userInfo:@{NSLocalizedDescriptionKey:@"PICKER_WAS_CANCELLED"}];
-        rejectBlock(@"CANCELLED",@"CANCELLED",error);
-    }
+    [self completeDocumentPicker:controller success:NO];
 }
 
 - (void)documentPicker:(UIDocumentPickerViewController *)controller didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
-    if (resolveBlock) {
-        resolveBlock(@{
-            @"success": @(YES),
-            @"message": @"com.apple.DocumentsApp"
-        });
-    }
+    [self completeDocumentPicker:controller success:YES];
+}
+
+- (void)completeDocumentPicker:(UIDocumentPickerViewController *)controller success:(BOOL)success {
+    if (controller != activeDocumentPicker || !documentPickerResolve) return;
+    RCTPromiseResolveBlock resolve = documentPickerResolve;
+    documentPickerResolve = nil;
+    activeDocumentPicker = nil;
+    controller.delegate = nil;
+    resolve(@{
+        @"success": @(success),
+        @"message": success ? @"com.apple.DocumentsApp" : @"CANCELED"
+    });
 }
 
 #pragma mark - Share Controller
@@ -367,27 +361,20 @@ RCT_EXPORT_METHOD(isPackageInstalled:(NSString *)packagename
 
     __weak UIActivityViewController* weakShareController = shareController;
     shareController.completionWithItemsHandler = ^(NSString *activityType, BOOL completed, __unused NSArray *returnedItems, NSError *activityError) {
+        UIActivityViewController *completedController = weakShareController;
+        if (!completedController.completionWithItemsHandler) return;
+        completedController.completionWithItemsHandler = nil;
         // always dismiss since this may be called from cancelled shares
         // but the share menu would remain open, and our callback would fire again on close
-        if(weakShareController){
-            // closing activity view controller
-            [weakShareController dismissViewControllerAnimated:true completion:nil];
-        } else {
-            [controller dismissViewControllerAnimated:true completion:nil];
-        }
+        [completedController dismissViewControllerAnimated:true completion:nil];
 
         if (activityError) {
             reject(@"error",@"activityError",activityError);
         } else {
             resolve(@{
                 @"success": @(completed),
-                @"message": (RCTNullIfNil(activityType) ?: @"")
+                @"message": activityType ?: @""
             });
-        }
-
-        // clear the completion handler to prevent cycles
-        if(weakShareController){
-            weakShareController.completionWithItemsHandler = nil;
         }
     };
 

--- a/ios/RNShare.mm
+++ b/ios/RNShare.mm
@@ -139,7 +139,9 @@ RCT_EXPORT_METHOD(shareSingle:(NSDictionary *)options
         } else if([social isEqualToString:@"instagram"]) {
             NSLog(@"TRY OPEN instagram");
             InstagramShare *shareCtl = [[InstagramShare alloc] init];
-            if([self isImageMimeType:[RCTConvert NSString:options[@"url"]]]) {// Condition to handle image
+            NSString *shareURL = [RCTConvert NSString:options[@"url"]];
+            NSString *shareType = [RCTConvert NSString:options[@"type"]];
+            if ([self isImageMimeType:shareURL] || [shareType.lowercaseString hasPrefix:@"image/"]) {
                 [shareCtl shareSingleImage:options reject: reject resolve: resolve];
             } else {
                 [shareCtl shareSingle:options reject: reject resolve: resolve];

--- a/ios/RNShareUtils.h
+++ b/ios/RNShareUtils.h
@@ -2,6 +2,9 @@
 
 @interface RNShareUtils : NSObject
 +(NSString*)getExtensionFromBase64:(NSString*)base64String;
++(NSString*)getMimeTypeFromBase64:(NSString*)base64String;
++(NSString*)getTypeIdentifierFromExtension:(NSString*)extension;
 +(NSURL*)getPathFromBase64:(NSString*)base64String with:(NSData*)data fileName:(NSString*)name;
 +(NSURL*)getPathFromFilename:(NSString*)filename with:(NSData*)data;
++(NSURL*)URLWithString:(NSString*)url queryItems:(NSArray<NSURLQueryItem*>*)queryItems;
 @end

--- a/ios/RNShareUtils.h
+++ b/ios/RNShareUtils.h
@@ -3,6 +3,7 @@
 @interface RNShareUtils : NSObject
 +(NSString*)getExtensionFromBase64:(NSString*)base64String;
 +(NSString*)getMimeTypeFromBase64:(NSString*)base64String;
++(NSString*)getMimeTypeFromExtension:(NSString*)extension;
 +(NSString*)getTypeIdentifierFromExtension:(NSString*)extension;
 +(NSURL*)getPathFromBase64:(NSString*)base64String with:(NSData*)data fileName:(NSString*)name;
 +(NSURL*)getPathFromFilename:(NSString*)filename with:(NSData*)data;

--- a/ios/RNShareUtils.m
+++ b/ios/RNShareUtils.m
@@ -32,6 +32,20 @@
     return mimeType.length == 0 ? @"text/plain" : mimeType;
 }
 
++(NSString*)getMimeTypeFromExtension:(NSString*)extension {
+    if (extension.length == 0) return nil;
+#if __has_include(<UniformTypeIdentifiers/UniformTypeIdentifiers.h>)
+    if (@available(iOS 14.0, macCatalyst 14.0, macOS 11.0, *)) {
+        return [UTType typeWithFilenameExtension:extension].preferredMIMEType;
+    }
+#endif
+    CFStringRef identifier = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)extension, NULL);
+    if (identifier == NULL) return nil;
+    NSString *mimeType = CFBridgingRelease(UTTypeCopyPreferredTagWithClass(identifier, kUTTagClassMIMEType));
+    CFRelease(identifier);
+    return mimeType;
+}
+
 +(NSString*)getExtensionFromBase64:(NSString*)base64String {
     NSString *mimeType = [self getMimeTypeFromBase64:base64String];
     if (!mimeType) return nil;
@@ -77,7 +91,10 @@
         fileName=@"file";
     }
 
-    NSString *pathComponent = [NSString stringWithFormat:@"%@.%@",fileName, mimeType];
+    NSString *safeName = fileName.length > 0 ? fileName : @"file";
+    NSString *pathComponent = safeName.pathExtension.length > 0
+        ? safeName
+        : [safeName stringByAppendingPathExtension:mimeType ?: @"bin"];
     return [self getPathFromFilename:pathComponent with:data];
 }
 

--- a/ios/RNShareUtils.m
+++ b/ios/RNShareUtils.m
@@ -1,28 +1,62 @@
 #import "RNShareUtils.h"
+#import <MobileCoreServices/MobileCoreServices.h>
+#if __has_include(<UniformTypeIdentifiers/UniformTypeIdentifiers.h>)
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+#endif
 
 
 @implementation RNShareUtils
+
++(NSURL*)URLWithString:(NSString*)url queryItems:(NSArray<NSURLQueryItem*>*)queryItems {
+    NSURLComponents *components = [NSURLComponents componentsWithString:url];
+    components.queryItems = queryItems;
+    // Query-item encoding permits '+', but many target apps decode it as a space.
+    components.percentEncodedQuery = [components.percentEncodedQuery stringByReplacingOccurrencesOfString:@"+" withString:@"%2B"];
+    return components.URL;
+}
 
 
 /**
  Given a base64 string, attempts to return a file extension based on its mime type.
 */
-+(NSString*)getExtensionFromBase64:(NSString*)base64String {
-    NSRange   searchedRange = NSMakeRange(0, [base64String length]);
-    NSString *pattern = @"/[a-zA-Z0-9]+;";
-    NSError  *error = nil;
-
-    NSRegularExpression* regex = [NSRegularExpression regularExpressionWithPattern: pattern options:0 error:&error];
-    NSArray* matches = [regex matchesInString:base64String options:0 range: searchedRange];
-    
-    NSString *ext = nil;
-    
-    for (NSTextCheckingResult* match in matches) {
-        NSString* matchText = [base64String substringWithRange:[match range]];
-        ext = [matchText substringWithRange:(NSMakeRange(1, matchText.length - 2))];
++(NSString*)getMimeTypeFromBase64:(NSString*)base64String {
+    if (base64String.length < 5 || [base64String compare:@"data:" options:NSCaseInsensitiveSearch range:NSMakeRange(0, 5)] != NSOrderedSame) {
+        return nil;
     }
+    NSRange comma = [base64String rangeOfString:@","];
+    if (comma.location == NSNotFound) return nil;
+    NSRange header = NSMakeRange(5, comma.location - 5);
+    NSRange separator = [base64String rangeOfString:@";" options:0 range:header];
+    NSUInteger end = separator.location == NSNotFound ? comma.location : separator.location;
+    NSString *mimeType = [base64String substringWithRange:NSMakeRange(5, end - 5)];
+    return mimeType.length == 0 ? @"text/plain" : mimeType;
+}
 
-    return ext;
++(NSString*)getExtensionFromBase64:(NSString*)base64String {
+    NSString *mimeType = [self getMimeTypeFromBase64:base64String];
+    if (!mimeType) return nil;
+
+#if __has_include(<UniformTypeIdentifiers/UniformTypeIdentifiers.h>)
+    if (@available(iOS 14.0, macCatalyst 14.0, macOS 11.0, *)) {
+        return [UTType typeWithMIMEType:mimeType].preferredFilenameExtension;
+    }
+#endif
+    CFStringRef identifier = UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, (__bridge CFStringRef)mimeType, NULL);
+    if (identifier == NULL) return nil;
+    NSString *extension = CFBridgingRelease(UTTypeCopyPreferredTagWithClass(identifier, kUTTagClassFilenameExtension));
+    CFRelease(identifier);
+    return extension;
+}
+
++(NSString*)getTypeIdentifierFromExtension:(NSString*)extension {
+    if (extension.length == 0) return @"public.data";
+#if __has_include(<UniformTypeIdentifiers/UniformTypeIdentifiers.h>)
+    if (@available(iOS 14.0, macCatalyst 14.0, macOS 11.0, *)) {
+        return [UTType typeWithFilenameExtension:extension].identifier ?: @"public.data";
+    }
+#endif
+    NSString *identifier = CFBridgingRelease(UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)extension, NULL));
+    return identifier ?: @"public.data";
 }
 
 /**
@@ -44,22 +78,27 @@
     }
 
     NSString *pathComponent = [NSString stringWithFormat:@"%@.%@",fileName, mimeType];
-    NSString *writePath = [NSTemporaryDirectory() stringByAppendingPathComponent:pathComponent];
-    if ([data writeToFile:writePath atomically:YES]) {
-        return [NSURL fileURLWithPath:writePath];
-    }
-    return NULL;
+    return [self getPathFromFilename:pathComponent with:data];
 }
 
 /**
  Given a filename string and Data, writes a temp file with the filename.
  */
 +(NSURL*)getPathFromFilename:(NSString*)filename with:(NSData*)data {
-    NSString *writePath = [NSTemporaryDirectory() stringByAppendingPathComponent:filename];
-    if ([data writeToFile:writePath atomically:YES]) {
-        return [NSURL fileURLWithPath:writePath];
+    if (data == nil || filename.length == 0 || [filename isEqualToString:@"."] || [filename isEqualToString:@".."] || [filename rangeOfCharacterFromSet:[NSCharacterSet characterSetWithCharactersInString:@"/\\"]].location != NSNotFound) {
+        return nil;
     }
-    return NULL;
+    NSString *directory = [NSTemporaryDirectory() stringByAppendingPathComponent:NSUUID.UUID.UUIDString];
+    NSFileManager *manager = NSFileManager.defaultManager;
+    if (![manager createDirectoryAtPath:directory withIntermediateDirectories:YES attributes:nil error:nil]) {
+        return nil;
+    }
+    NSString *writePath = [directory stringByAppendingPathComponent:filename];
+    if (![data writeToFile:writePath atomically:YES]) {
+        [manager removeItemAtPath:directory error:nil];
+        return nil;
+    }
+    return [NSURL fileURLWithPath:writePath];
 }
 
 @end

--- a/ios/SmsShare.m
+++ b/ios/SmsShare.m
@@ -1,108 +1,88 @@
 #import "SmsShare.h"
 #import "RNShareUtils.h"
 
-
-@implementation SmsShare
-
+@implementation SmsShare {
+    MFMessageComposeViewController *activeController;
+}
 
 - (void)shareSingle:(NSDictionary *)options
-    reject:(RCTPromiseRejectBlock)reject
-    resolve:(RCTPromiseResolveBlock)resolve {
+            reject:(RCTPromiseRejectBlock)reject
+           resolve:(RCTPromiseResolveBlock)resolve {
+    if (activeController) {
+        reject(@"EINPROGRESS", @"An SMS composer is already open", nil);
+        return;
+    }
+    NSString *message = [RCTConvert NSString:options[@"message"]] ?: @"";
+    NSString *recipient = [RCTConvert NSString:options[@"recipient"]];
+    NSURL *URL = [RCTConvert NSURL:options[@"url"]];
+    if (message.length == 0 && !URL) {
+        reject(@"EINVAL", @"A message or URL is required", nil);
+        return;
+    }
+    if (![MFMessageComposeViewController canSendText]) {
+        reject(@"com.rnshare", @"SMS services are not available.", nil);
+        return;
+    }
 
-    if ([options objectForKey:@"message"] && [options objectForKey:@"message"] != [NSNull null]) {
+    MFMessageComposeViewController *mc = [[MFMessageComposeViewController alloc] init];
+    mc.messageComposeDelegate = self;
+    mc.recipients = recipient.length > 0 ? @[recipient] : @[];
 
-        NSString *message = [RCTConvert NSString:options[@"message"]];
-        NSString *recipient = [RCTConvert NSString:options[@"recipient"]];
+    if (URL) {
+        BOOL isDataScheme = [URL.scheme.lowercaseString isEqualToString:@"data"];
+        if (isDataScheme || URL.isFileURL) {
+            NSError *error;
+            NSData *data = [NSData dataWithContentsOfURL:URL options:0 error:&error];
+            if (!data) {
+                reject(@"com.rnshare", @"No data", error);
+                return;
+            }
+            NSString *extension = isDataScheme ? [RNShareUtils getExtensionFromBase64:URL.absoluteString] : URL.pathExtension;
+            NSString *filename = URL.isFileURL ? URL.lastPathComponent : (extension.length > 0 ? [@"file" stringByAppendingPathExtension:extension] : @"file");
+            NSString *identifier = [RNShareUtils getTypeIdentifierFromExtension:extension];
+            if (![mc addAttachmentData:data typeIdentifier:identifier filename:filename]) {
+                reject(@"com.rnshare", @"Unable to attach file to SMS", nil);
+                return;
+            }
+        } else {
+            NSString *url = [RCTConvert NSString:options[@"url"]];
+            message = message.length > 0 ? [NSString stringWithFormat:@"%@ %@", message, url] : url;
+        }
+    }
+    mc.body = message;
+    activeController = mc;
+    self.resolve = resolve;
+    self.reject = reject;
 
-        if (![MFMessageComposeViewController canSendText]) {
-            NSString *errorMessage = @"Sms services is not available.";
-            NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};
-            NSError *error = [NSError errorWithDomain:@"com.rnshare" code:1 userInfo:userInfo];
-            reject(@"com.rnshare", errorMessage, error);
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIViewController *controller = RCTPresentedViewController();
+        if (!controller) {
+            self.resolve = nil;
+            self.reject = nil;
+            activeController = nil;
+            reject(@"EUNAVAILABLE", @"No view controller available to present SMS", nil);
             return;
         }
-
-        // Store callbacks for use in delegate
-        self.resolve = resolve;
-        self.reject = reject;
-
-        MFMessageComposeViewController *mc = [[MFMessageComposeViewController alloc] init];
-        mc.messageComposeDelegate = self;
-
-        NSMutableArray *recipients = [[NSMutableArray alloc] init];
-        if (recipient && ![recipient isEqual: @""]) {
-            [recipients addObject:recipient];
-        }
-        mc.recipients = recipients;
-        mc.body = message;
-
-        NSURL *URL = [RCTConvert NSURL:options[@"url"]];
-        if (URL) {
-            BOOL isDataScheme = [URL.scheme.lowercaseString isEqualToString:@"data"];
-
-            // Only handling data scheme urls here. To handle the case of URL.isFileURL
-            // one could add a case similar to the process in EmailShare.m
-            if (isDataScheme) {
-                NSError *error;
-                NSData *data = [NSData dataWithContentsOfURL:URL
-                                                     options:(NSDataReadingOptions)0
-                                                       error:&error];
-                if (!data) {
-                    self.resolve = nil;
-                    self.reject = nil;
-                    reject(@"com.rnshare", @"No data", error);
-                    return;
-                }
-
-                NSURL *filePath = [RNShareUtils getPathFromBase64:URL.absoluteString with:data fileName:@"file"];
-                if (filePath) {
-                    // public.image typeIdentifier works for both images and files
-                    [mc addAttachmentData:data typeIdentifier:@"public.image" filename:filePath.absoluteString];
-                }
-            } else if (URL.isFileURL) {
-                NSError *error;
-                NSData *data = [NSData dataWithContentsOfURL:URL
-                                                     options:(NSDataReadingOptions)0
-                                                       error:&error];
-                if (data) {
-                    NSString *filename = URL.lastPathComponent ?: @"file";
-                    [mc addAttachmentData:data typeIdentifier:@"public.image" filename:filename];
-                }
-            } else {
-                // if not a file, just append URL to message
-                NSString *urlString = [RCTConvert NSString:options[@"url"]];
-                message = [message stringByAppendingString: [@" " stringByAppendingString:  urlString]];
-                [mc setBody:message];
-            }
-        }
-
-
-        dispatch_async(dispatch_get_main_queue(), ^{
-            UIViewController *ctrl = RCTPresentedViewController();
-            [ctrl presentViewController:mc animated:YES completion:NULL];
-        });
-    }
+        [controller presentViewController:mc animated:YES completion:nil];
+    });
 }
 
 - (void)messageComposeViewController:(MFMessageComposeViewController *)controller
-                 didFinishWithResult:(MessageComposeResult)result {
+                didFinishWithResult:(MessageComposeResult)result {
     dispatch_async(dispatch_get_main_queue(), ^{
-        UIViewController *ctrl = RCTPresentedViewController();
-        [ctrl dismissViewControllerAnimated:YES completion:^{
+        if (controller != activeController || !self.resolve) return;
+        RCTPromiseResolveBlock resolve = self.resolve;
+        RCTPromiseRejectBlock reject = self.reject;
+        self.resolve = nil;
+        self.reject = nil;
+        controller.messageComposeDelegate = nil;
+        [controller dismissViewControllerAnimated:YES completion:^{
+            activeController = nil;
             if (result == MessageComposeResultFailed) {
-                if (self.reject) {
-                    NSString *errorMessage = @"Failed to send SMS.";
-                    NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};
-                    NSError *error = [NSError errorWithDomain:@"com.rnshare" code:1 userInfo:userInfo];
-                    self.reject(@"com.rnshare", errorMessage, error);
-                }
+                reject(@"com.rnshare", @"Failed to send SMS.", nil);
             } else {
-                if (self.resolve) {
-                    self.resolve(@[@(result == MessageComposeResultSent), @""]);
-                }
+                resolve(@[@(result == MessageComposeResultSent), @""]);
             }
-            self.resolve = nil;
-            self.reject = nil;
         }];
     });
 }

--- a/ios/TelegramShare.m
+++ b/ios/TelegramShare.m
@@ -6,8 +6,7 @@
 //
 
 #import "TelegramShare.h"
-#import <AVFoundation/AVFoundation.h>
-@import Photos;
+#import "RNShareUtils.h"
 
 @implementation TelegramShare
     RCT_EXPORT_MODULE();
@@ -15,20 +14,24 @@
     reject:(RCTPromiseRejectBlock)reject
     resolve:(RCTPromiseResolveBlock)resolve {
     
-    NSString *text = [RCTConvert NSString:options[@"message"]];
-    text = (NSString*)CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(NULL,(CFStringRef) text, NULL,CFSTR("!*'();:@&=+$,/?%#[]"),kCFStringEncodingUTF8));
-    
+    NSString *text = [RCTConvert NSString:options[@"message"]] ?: @"";
     NSString *url = [RCTConvert NSString:options[@"url"]];
+    if (text.length == 0 && url.length == 0) {
+        reject(@"EINVAL", @"A message or URL is required", nil);
+        return;
+    }
+    NSMutableArray *queryItems = [NSMutableArray arrayWithObject:[NSURLQueryItem queryItemWithName:@"text" value:text]];
+    if (url.length > 0) [queryItems addObject:[NSURLQueryItem queryItemWithName:@"url" value:url]];
+    NSURL *shareURL = [RNShareUtils URLWithString:url.length > 0 ? @"tg://msg_url" : @"tg://msg" queryItems:queryItems];
 
-    NSString *telegramMsg = [NSString stringWithFormat:@"tg://msg?text=%@", text];
-    NSString *telegramMsgUrl = [NSString stringWithFormat:@"tg://msg_url?text=%@&url=%@", text, url];
-
-    NSString * urlTelegram = url ? telegramMsgUrl : telegramMsg;
-    NSURL * shareURL = [NSURL URLWithString:urlTelegram];
-    
     if ([[UIApplication sharedApplication] canOpenURL: shareURL]) {
-        [[UIApplication sharedApplication] openURL: shareURL options:@{} completionHandler:nil];
-        resolve(@[@true, @""]);
+        [[UIApplication sharedApplication] openURL:shareURL options:@{} completionHandler:^(BOOL success) {
+            if (success) {
+                resolve(@[@true, @""]);
+            } else {
+                reject(@"EUNAVAILABLE", @"Unable to open share target", nil);
+            }
+        }];
     } else {
         // Cannot open telegram
         NSString *stringURL = @"https://itunes.apple.com/app/telegram-messenger/id686449807";

--- a/ios/TwitterShare.m
+++ b/ios/TwitterShare.m
@@ -6,8 +6,7 @@
 //
 
 #import "TwitterShare.h"
-#import <AVFoundation/AVFoundation.h>
-@import Photos;
+#import "RNShareUtils.h"
 
 @implementation TwitterShare
 RCT_EXPORT_MODULE();
@@ -15,34 +14,29 @@ RCT_EXPORT_MODULE();
 - (void)shareSingle:(NSDictionary *)options
              reject:(RCTPromiseRejectBlock)reject
             resolve:(RCTPromiseResolveBlock)resolve {
-    
-    NSString *text = [RCTConvert NSString:options[@"message"]];
+    NSString *text = [RCTConvert NSString:options[@"message"]] ?: @"";
     NSString *url = [RCTConvert NSString:options[@"url"]];
-
-    // URL encode text and url
-    NSString *encodedText = (NSString*)CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(
-        NULL, (CFStringRef)text, NULL, CFSTR("!*'();:@&=+$,/?%#[]"), kCFStringEncodingUTF8));
-
-    NSString *encodedUrl = url ? (NSString*)CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(
-        NULL, (CFStringRef)url, NULL, CFSTR("!*'();:@&=+$,/?%#[]"), kCFStringEncodingUTF8)) : nil;
-
-    // First try deep link to app
-    NSString *appUrlString = [NSString stringWithFormat:@"twitter://post?message=%@", encodedText];
-    NSURL *appUrl = [NSURL URLWithString:appUrlString];
-
-    if ([[UIApplication sharedApplication] canOpenURL:appUrl]) {
-        [[UIApplication sharedApplication] openURL:appUrl options:@{} completionHandler:^(BOOL success) {}];
-        resolve(@[@true, @"opened in twitter app"]);
-    } else {
-        // Fallback to web intent
-        NSString *webUrlString = url ?
-            [NSString stringWithFormat:@"https://twitter.com/intent/tweet?text=%@&url=%@", encodedText, encodedUrl] :
-            [NSString stringWithFormat:@"https://twitter.com/intent/tweet?text=%@", encodedText];
-
-        NSURL *webUrl = [NSURL URLWithString:webUrlString];
-        [[UIApplication sharedApplication] openURL:webUrl options:@{} completionHandler:^(BOOL success) {}];
-        resolve(@[@true, @"opened in browser"]);
+    if (text.length == 0 && url.length == 0) {
+        reject(@"EINVAL", @"A message or URL is required", nil);
+        return;
     }
+
+    NSString *appMessage = text;
+    if (url.length > 0) appMessage = text.length > 0 ? [NSString stringWithFormat:@"%@ %@", text, url] : url;
+    NSURL *shareURL = [RNShareUtils URLWithString:@"twitter://post" queryItems:@[[NSURLQueryItem queryItemWithName:@"message" value:appMessage]]];
+    BOOL inApp = [[UIApplication sharedApplication] canOpenURL:shareURL];
+    if (!inApp) {
+        NSMutableArray *queryItems = [NSMutableArray arrayWithObject:[NSURLQueryItem queryItemWithName:@"text" value:text]];
+        if (url.length > 0) [queryItems addObject:[NSURLQueryItem queryItemWithName:@"url" value:url]];
+        shareURL = [RNShareUtils URLWithString:@"https://twitter.com/intent/tweet" queryItems:queryItems];
+    }
+    [[UIApplication sharedApplication] openURL:shareURL options:@{} completionHandler:^(BOOL success) {
+        if (success) {
+            resolve(@[@true, inApp ? @"opened in twitter app" : @"opened in browser"]);
+        } else {
+            reject(@"EUNAVAILABLE", @"Unable to open share target", nil);
+        }
+    }];
 }
 
 @end

--- a/ios/ViberShare.m
+++ b/ios/ViberShare.m
@@ -4,8 +4,7 @@
 //
 
 #import "ViberShare.h"
-#import <AVFoundation/AVFoundation.h>
-@import Photos;
+#import "RNShareUtils.h"
 
 @implementation ViberShare
     RCT_EXPORT_MODULE();
@@ -13,20 +12,23 @@
     reject:(RCTPromiseRejectBlock)reject
     resolve:(RCTPromiseResolveBlock)resolve {
     
-    NSString *text = [RCTConvert NSString:options[@"message"]];
-    text = (NSString*)CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(NULL,(CFStringRef) text, NULL,CFSTR("!*'();:@&=+$,/?%#[]"),kCFStringEncodingUTF8));
-    
+    NSString *text = [RCTConvert NSString:options[@"message"]] ?: @"";
     NSString *url = [RCTConvert NSString:options[@"url"]];
+    if (text.length == 0 && url.length == 0) {
+        reject(@"EINVAL", @"A message or URL is required", nil);
+        return;
+    }
+    if (url.length > 0) text = text.length > 0 ? [NSString stringWithFormat:@"%@ %@", text, url] : url;
+    NSURL *shareURL = [RNShareUtils URLWithString:@"viber://forward" queryItems:@[[NSURLQueryItem queryItemWithName:@"text" value:text]]];
 
-    NSString *viberMsg = [NSString stringWithFormat:@"viber://forward?text=%@", text];
-    NSString *viberMsgUrl = [NSString stringWithFormat:@"viber://forward?text=%@ %@", text, url];
-
-    NSString * urlViber = url ? viberMsgUrl : viberMsg;
-    NSURL * shareURL = [NSURL URLWithString:urlViber];
-    
     if ([[UIApplication sharedApplication] canOpenURL: shareURL]) {
-        [[UIApplication sharedApplication] openURL: shareURL options:@{} completionHandler:nil];
-        resolve(@[@true, @""]);
+        [[UIApplication sharedApplication] openURL:shareURL options:@{} completionHandler:^(BOOL success) {
+            if (success) {
+                resolve(@[@true, @""]);
+            } else {
+                reject(@"EUNAVAILABLE", @"Unable to open share target", nil);
+            }
+        }];
     } else {
         // Cannot open viber
         NSString *stringURL = @"https://apps.apple.com/app/viber-messenger-chats-calls/id382617920";

--- a/ios/WhatsAppShare.m
+++ b/ios/WhatsAppShare.m
@@ -7,6 +7,7 @@
 //
 
 #import "WhatsAppShare.h"
+#import "RNShareUtils.h"
 
 typedef NS_ENUM(NSInteger, MessageType) {
   MessageTypeImage,
@@ -15,186 +16,109 @@ typedef NS_ENUM(NSInteger, MessageType) {
   MessageTypeAudio
 };
 
-@implementation WhatsAppShare
-static UIDocumentInteractionController *documentInteractionController;
+@implementation WhatsAppShare {
+    UIDocumentInteractionController *documentInteractionController;
+    BOOL preparingMedia;
+    BOOL menuVisible;
+    BOOL sendingDocument;
+}
 RCT_EXPORT_MODULE();
 
-
-- (void) shareSingle:(NSDictionary *)options
-reject:(RCTPromiseRejectBlock)reject
-resolve:(RCTPromiseResolveBlock)resolve {
-    
-    NSLog(@"Try open view");
-    
-    if(![self isAbleToSendMessage: options]){
+- (void)shareSingle:(NSDictionary *)options
+            reject:(RCTPromiseRejectBlock)reject
+           resolve:(RCTPromiseResolveBlock)resolve {
+    if (preparingMedia || menuVisible || sendingDocument) {
+        reject(@"EINPROGRESS", @"A WhatsApp media share is already in progress", nil);
         return;
     }
-    
-    if(![self isWhatsAppAvailable]) {
+    NSString *url = [RCTConvert NSString:options[@"url"]];
+    NSString *message = [RCTConvert NSString:options[@"message"]] ?: @"";
+    if (message.length == 0 && url.length == 0) {
+        reject(@"EINVAL", @"A message or URL is required", nil);
+        return;
+    }
+    if (![self isWhatsAppAvailable]) {
         [self handleError:@"Not Installed" code:1 rejectFn:reject];
         return;
     }
-    
-    MessageType messageType = [self getMessageType: options[@"url"]];
-    
-    switch(messageType) {
-      case MessageTypeImage:
-        [self tryToSendImage: options resolve:resolve reject:reject];
-        break;
-        
-      case MessageTypeVideo:
-        [self tryToSendVideo: options resolve:resolve reject:reject];
-        break;
-
-      case MessageTypeAudio:
-        [self tryToSendAudio:options resolve:resolve reject:reject];
-        break;
-        
-      default:
-        [self tryToSendText: options resolve:resolve reject:reject];
+    MessageType type = [self getMessageType:url];
+    if (type == MessageTypeText) {
+        if (url.length > 0) message = message.length > 0 ? [NSString stringWithFormat:@"%@ %@", message, url] : url;
+        NSMutableArray *queryItems = [NSMutableArray array];
+        NSString *phone = [RCTConvert NSString:options[@"whatsAppNumber"]];
+        if (phone.length > 0) [queryItems addObject:[NSURLQueryItem queryItemWithName:@"phone" value:phone]];
+        [queryItems addObject:[NSURLQueryItem queryItemWithName:@"text" value:message]];
+        NSURL *URL = [RNShareUtils URLWithString:@"whatsapp://send" queryItems:queryItems];
+        [[UIApplication sharedApplication] openURL:URL options:@{} completionHandler:^(BOOL success) {
+            if (success) {
+                resolve(@[@true, @""]);
+            } else {
+                [self handleError:@"Unable to open WhatsApp" code:2 rejectFn:reject];
+            }
+        }];
+        return;
     }
-    
-}
 
--(void)tryToSendImage:(NSDictionary *)options
-              resolve:(RCTPromiseResolveBlock)resolve
-              reject:(RCTPromiseRejectBlock)reject {
-  UIImage *image;
-  NSURL *imageURL = [RCTConvert NSURL:options[@"url"]];
-  if(imageURL){
-    if (imageURL.fileURL || [imageURL.scheme.lowercaseString isEqualToString:@"data"]) {
-        NSError *error;
-        NSData *data = [NSData dataWithContentsOfURL:imageURL
-                                             options:(NSDataReadingOptions)0
-                                               error:&error];
-        if (!data) {
-          return [self handleError:@"Something went wrong" code:2 rejectFn:reject];
+    preparingMedia = YES;
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        NSURL *URL = [url hasPrefix:@"/"] ? [NSURL fileURLWithPath:url] : [RCTConvert NSURL:url];
+        BOOL isData = [URL.scheme.lowercaseString isEqualToString:@"data"];
+        NSURL *preparedURL = nil;
+        if (type == MessageTypeImage) {
+            NSData *data = URL ? [NSData dataWithContentsOfURL:URL] : nil;
+            UIImage *image = data ? [UIImage imageWithData:data] : nil;
+            NSData *jpeg = image ? UIImageJPEGRepresentation(image, 1.0) : nil;
+            if (jpeg) preparedURL = [RNShareUtils getPathFromFilename:@"image.jpg" with:jpeg];
+        } else if (isData) {
+            NSData *data = [NSData dataWithContentsOfURL:URL];
+            NSString *extension = [RNShareUtils getExtensionFromBase64:url] ?: (type == MessageTypeVideo ? @"mp4" : @"mp3");
+            if (data) preparedURL = [RNShareUtils getPathFromFilename:[@"file" stringByAppendingPathExtension:extension] with:data];
+        } else if (URL.isFileURL) {
+            BOOL directory = NO;
+            NSFileManager *manager = NSFileManager.defaultManager;
+            if ([manager fileExistsAtPath:URL.path isDirectory:&directory] && !directory && [manager isReadableFileAtPath:URL.path]) {
+                preparedURL = URL;
+            }
         }
-      
-        image = [UIImage imageWithData: data];
-        NSString *tempPath = NSTemporaryDirectory();
-        NSString *filePath = [tempPath stringByAppendingPathComponent:@"image.jpg"];
-        
-        [UIImageJPEGRepresentation(image, 1.0) writeToFile:filePath atomically:YES];
-      
-        [self shareMedia:filePath documentUTI:@"net.whatsapp.image"];
-      
-        resolve(@[@true, @""]);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            preparingMedia = NO;
+            if (!preparedURL) {
+                [self handleError:@"Unable to prepare media attachment" code:2 rejectFn:reject];
+                return;
+            }
+            NSString *UTI = type == MessageTypeImage ? @"net.whatsapp.image" : type == MessageTypeVideo ? @"net.whatsapp.movie" : @"net.whatsapp.audio";
+            [self shareMedia:preparedURL documentUTI:UTI resolve:resolve reject:reject];
+        });
+    });
+}
+
+- (MessageType)getMessageType:(NSString *)url {
+    if (url.length == 0) return MessageTypeText;
+    if (url.length >= 5 && [url compare:@"data:" options:NSCaseInsensitiveSearch range:NSMakeRange(0, 5)] == NSOrderedSame) {
+        NSString *mime = [RNShareUtils getMimeTypeFromBase64:url].lowercaseString;
+        if ([mime hasPrefix:@"image/"]) return MessageTypeImage;
+        if ([mime hasPrefix:@"video/"]) return MessageTypeVideo;
+        if ([mime hasPrefix:@"audio/"]) return MessageTypeAudio;
+        return MessageTypeText;
     }
-
-  }else {
-    [self handleError:@"Something went wrong" code:3 rejectFn:reject];
-  }
-  
-}
-
--(void)tryToSendVideo:(NSDictionary *)options
-              resolve:(RCTPromiseResolveBlock)resolve
-              reject:(RCTPromiseRejectBlock)reject {
-  
-  NSLog(@"Sending whatsapp movie");
-  [self shareMedia:options[@"url"] documentUTI:@"net.whatsapp.movie"];
-  NSLog(@"Done whatsapp movie");
-  resolve(@[@true, @""]);
-}
-
-- (void)tryToSendAudio:(NSDictionary *)options
-               resolve:(RCTPromiseResolveBlock)resolve
-               reject:(RCTPromiseRejectBlock)reject {
-
-  NSLog(@"Sending whatsapp audio");
-  [self shareMedia:options[@"url"] documentUTI:@"net.whatsapp.audio"];
-  NSLog(@"Done whatsapp audio");
-  resolve(@[ @true, @"" ]);
-}
-
--(void)tryToSendText:(NSDictionary *)options
-             resolve:(RCTPromiseResolveBlock)resolve
-             reject:(RCTPromiseRejectBlock)reject {
-  
-  NSString *text = [RCTConvert NSString:options[@"message"]];
-  if (options[@"url"] && options[@"url"] != [NSNull null]) {
-    text = [text stringByAppendingString: [@" " stringByAppendingString: options[@"url"]] ];
-  }
-  NSString *whatsAppNumber = [RCTConvert NSString:options[@"whatsAppNumber"]];
-  
-  text = (NSString*)CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(NULL,(CFStringRef) text, NULL,CFSTR("!*'();:@&=+$,/?%#[]"),kCFStringEncodingUTF8));
-  
-  NSString * urlWhats = whatsAppNumber ? [NSString stringWithFormat:@"whatsapp://send?phone=%@&text=%@", whatsAppNumber, text] : [NSString stringWithFormat:@"whatsapp://send?text=%@", text];
-  NSURL * whatsappURL = [NSURL URLWithString:urlWhats];
-  
-  if ([[UIApplication sharedApplication] canOpenURL: whatsappURL]) {
-      [[UIApplication sharedApplication] openURL:whatsappURL options:@{} completionHandler:nil];
-      resolve(@[@true, @""]);
-  }
-}
-
-
--(MessageType)getMessageType: (NSString *)url {
-  if (!url || url.length == 0) {
+    NSURL *URL = [url hasPrefix:@"/"] ? [NSURL fileURLWithPath:url] : [NSURL URLWithString:url];
+    if (!URL.isFileURL) return MessageTypeText;
+    NSString *extension = URL.pathExtension.lowercaseString;
+    if ([@[@"png", @"jpeg", @"jpg", @"gif"] containsObject:extension]) return MessageTypeImage;
+    if ([@[@"wam", @"mp4"] containsObject:extension]) return MessageTypeVideo;
+    if ([@[@"mp3", @"aac", @"ogg", @"wav", @"m4a"] containsObject:extension]) return MessageTypeAudio;
     return MessageTypeText;
-  }
-  NSURL *parsed = [NSURL URLWithString:url];
-  NSString *scheme = parsed.scheme.lowercaseString;
-  BOOL isFileOrData = scheme && ([scheme isEqualToString:@"file"] || [scheme isEqualToString:@"data"]);
-  BOOL isAbsolutePath = [url hasPrefix:@"/"];
-  if (!isFileOrData && !isAbsolutePath) {
-    return MessageTypeText;
-  }
-  NSArray *imageExtensions = @[@"png", @"jpeg",@"jpg",@"gif"];
-  if([self isMediaType:url mediaExtensions: imageExtensions]){
-    return MessageTypeImage;
-  }
-  
-  NSArray *videoExtensions = @[@".wam", @".mp4"];
-  if([self isMediaType:url mediaExtensions:videoExtensions]){
-    return MessageTypeVideo;
-  }
-
-  NSArray *audioExtensions = @[@".mp3", @".aac", @".ogg", @".wav", @".m4a"];
-  if ([self isMediaType:url mediaExtensions:audioExtensions]) {
-    return MessageTypeAudio;
-  }
-  
-  return MessageTypeText;
 }
 
--(BOOL)isMediaType:(NSString *)url mediaExtensions:(NSArray *)mediaExtensions {
-  for(NSString *extension in mediaExtensions){
-    if([url rangeOfString:extension].location != NSNotFound){
-      return TRUE;
-    }
-  }
-  return FALSE;
+- (BOOL)isWhatsAppAvailable {
+    if ([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:@"whatsapp://app"]]) return YES;
+    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://itunes.apple.com/app/whatsapp-messenger/id310633997"] options:@{} completionHandler:nil];
+    return NO;
 }
 
--(BOOL)isWhatsAppAvailable {
-  if([[UIApplication sharedApplication] canOpenURL: [NSURL URLWithString:@"whatsapp://app"]]) {
-    NSLog(@"WhastApp installed");
-    return true;
-  }else {
-      // Cannot open whatsapp
-      NSString *appStoreStringURL = @"https://itunes.apple.com/app/whatsapp-messenger/id310633997";
-      NSURL *appStoreURL = [NSURL URLWithString:appStoreStringURL];
-      [[UIApplication sharedApplication] openURL:appStoreURL options:@{} completionHandler:nil];
-      return false;
-  }
-}
-
--(void)handleError:(NSString *)errorMessage code:(NSInteger)code rejectFn:(RCTPromiseRejectBlock)rejectFn {
-  NSDictionary *userInfo = @{NSLocalizedFailureReasonErrorKey: NSLocalizedString(errorMessage, nil)};
-  NSError *error = [NSError errorWithDomain:@"com.rnshare" code:code userInfo:userInfo];
-  
-  NSLog(@"%@", errorMessage);
-  return rejectFn(@"com.rnshare",errorMessage,error);
-}
-
-
--(BOOL)isAbleToSendMessage:(NSDictionary *) options {
-  if([options objectForKey:@"message"] && [options objectForKey:@"message"] != [NSNull null]){
-    return TRUE;
-  }
-  return FALSE;
+- (void)handleError:(NSString *)message code:(NSInteger)code rejectFn:(RCTPromiseRejectBlock)reject {
+    NSError *error = [NSError errorWithDomain:@"com.rnshare" code:code userInfo:@{NSLocalizedFailureReasonErrorKey: message}];
+    reject(@"com.rnshare", message, error);
 }
 
 -(UIView *)presentationView {
@@ -245,17 +169,48 @@ resolve:(RCTPromiseResolveBlock)resolve {
   return viewController.view;
 }
 
--(void)shareMedia:(NSString *)stringURL documentUTI:(NSString *)documentUTI {
-  NSURL *filePath = [NSURL fileURLWithPath:stringURL];
-  documentInteractionController = [UIDocumentInteractionController interactionControllerWithURL:filePath];
-  documentInteractionController.UTI = documentUTI;
-  documentInteractionController.delegate = self;
-  UIView *view = [self presentationView];
-  if (view == nil) {
-    NSLog(@"Unable to find a presentation view for WhatsApp share");
-    return;
-  }
-  [documentInteractionController presentOpenInMenuFromRect:view.bounds inView:view animated:YES];
+
+- (void)shareMedia:(NSURL *)URL
+      documentUTI:(NSString *)documentUTI
+          resolve:(RCTPromiseResolveBlock)resolve
+           reject:(RCTPromiseRejectBlock)reject {
+    UIView *view = [self presentationView];
+    if (!view || ![[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:@"whatsapp://app"]]) {
+        [self handleError:@"Unable to present WhatsApp media share" code:3 rejectFn:reject];
+        return;
+    }
+    documentInteractionController = [UIDocumentInteractionController interactionControllerWithURL:URL];
+    documentInteractionController.UTI = documentUTI;
+    documentInteractionController.delegate = self;
+    sendingDocument = NO;
+    menuVisible = YES;
+    if (![documentInteractionController presentOpenInMenuFromRect:view.bounds inView:view animated:YES]) {
+        menuVisible = NO;
+        documentInteractionController.delegate = nil;
+        documentInteractionController = nil;
+        [self handleError:@"Unable to present WhatsApp media share" code:3 rejectFn:reject];
+        return;
+    }
+    resolve(@[@true, @""]);
+}
+
+- (void)documentInteractionControllerDidDismissOpenInMenu:(UIDocumentInteractionController *)controller {
+    if (controller == documentInteractionController) menuVisible = NO;
+    // Retain the controller through handoff; dismissal can precede its sending callbacks.
+}
+
+- (void)documentInteractionController:(UIDocumentInteractionController *)controller
+       willBeginSendingToApplication:(NSString *)application {
+    if (controller == documentInteractionController) sendingDocument = YES;
+}
+
+- (void)documentInteractionController:(UIDocumentInteractionController *)controller
+          didEndSendingToApplication:(NSString *)application {
+    if (controller != documentInteractionController) return;
+    sendingDocument = NO;
+    menuVisible = NO;
+    controller.delegate = nil;
+    documentInteractionController = nil;
 }
 
 @end

--- a/ios/WhatsAppShare.m
+++ b/ios/WhatsAppShare.m
@@ -64,19 +64,21 @@ RCT_EXPORT_MODULE();
         NSURL *URL = [url hasPrefix:@"/"] ? [NSURL fileURLWithPath:url] : [RCTConvert NSURL:url];
         BOOL isData = [URL.scheme.lowercaseString isEqualToString:@"data"];
         NSURL *preparedURL = nil;
-        if (type == MessageTypeImage) {
-            NSData *data = URL ? [NSData dataWithContentsOfURL:URL] : nil;
-            UIImage *image = data ? [UIImage imageWithData:data] : nil;
-            NSData *jpeg = image ? UIImageJPEGRepresentation(image, 1.0) : nil;
-            if (jpeg) preparedURL = [RNShareUtils getPathFromFilename:@"image.jpg" with:jpeg];
-        } else if (isData) {
+        if (isData) {
             NSData *data = [NSData dataWithContentsOfURL:URL];
-            NSString *extension = [RNShareUtils getExtensionFromBase64:url] ?: (type == MessageTypeVideo ? @"mp4" : @"mp3");
-            if (data) preparedURL = [RNShareUtils getPathFromFilename:[@"file" stringByAppendingPathExtension:extension] with:data];
+            BOOL validImage = type != MessageTypeImage || [UIImage imageWithData:data] != nil;
+            NSString *fallbackExtension = type == MessageTypeImage ? @"jpg" : type == MessageTypeVideo ? @"mp4" : @"mp3";
+            NSString *extension = [RNShareUtils getExtensionFromBase64:url] ?: fallbackExtension;
+            if (data && validImage) {
+                preparedURL = [RNShareUtils getPathFromFilename:[@"file" stringByAppendingPathExtension:extension] with:data];
+            }
         } else if (URL.isFileURL) {
             BOOL directory = NO;
             NSFileManager *manager = NSFileManager.defaultManager;
-            if ([manager fileExistsAtPath:URL.path isDirectory:&directory] && !directory && [manager isReadableFileAtPath:URL.path]) {
+            BOOL readable = [manager fileExistsAtPath:URL.path isDirectory:&directory]
+                && !directory
+                && [manager isReadableFileAtPath:URL.path];
+            if (readable && (type != MessageTypeImage || [UIImage imageWithContentsOfFile:URL.path] != nil)) {
                 preparedURL = URL;
             }
         }

--- a/website/docs/share-open.mdx
+++ b/website/docs/share-open.mdx
@@ -93,6 +93,12 @@ When sharing a local file directly, you can use the following format:
 
 `url: "file://<file_path>"`
 
+### iOS completion and attachment names
+
+`saveToFiles` cancellation follows `failOnCancel`, just like cancellation of the regular share sheet. With `failOnCancel: false`, cancellation resolves with `success: false` and `dismissedAction: true`. An overlapping Files export rejects without replacing the first export's callback.
+
+Missing content, unavailable presentation, and failed attachment preparation reject instead of leaving the promise pending. For base64 attachments, each `filenames` entry applies only to the URL at that index; a missing entry falls back to `filename`, not the previous attachment's name. Custom names must be file names, not paths, and repeated names are isolated in separate temporary directories.
+
 ## ActivityItemSources (iOS only)
 
 In order to share different data according to activities or to customize the share sheet, you can provide the data by using `activityItemSources` .


### PR DESCRIPTION
## Fixes

- Isolate temporary attachment paths, validate display filenames, derive MIME/UTType from headers/extensions, and preserve each attachment's identity.
- Own Files/SMS/WhatsApp request state per adapter/module; prevent overlapping presentation from replacing callbacks, ignore stale delegates and clear terminal callbacks before reentrant completion.
- Reject empty/unsupported content, missing presenters, failed preparation, unavailable targets and failed launches instead of hanging or reporting success.
- Correct email/SMS attachment handling, URL-only content, file URLs, filenames/MIME, attachment rejection and controller ownership.
- Encode target URL query items without corrupting reserved characters or literal plus signs; retain existing social response shapes and fallback policy.
- Move image/video preparation off the main queue. Support limited Photos access, validate saved asset IDs and remove Instagram's lossy intermediate JPEG/file roundtrip and ineffective duration read.
- Validate Instagram/Facebook Stories inputs/assets and avoid writing the pasteboard when the target becomes unavailable.
- Preserve WhatsApp media identity, readable local files and request ownership through document handoff. Keep the scene-aware presenter selection.
- Validate native social composer content and report success only after presentation.

## Potentially breaking behavior

Invalid inputs, failed preparation and unavailable/failed launches now reject. Files cancellation follows `failOnCancel`; overlapping Files/SMS/WhatsApp requests reject instead of replacing pending ownership. Repeated filenames use separate temporary directories. Correct MIME extensions may differ from previous guessed names; Instagram's saved image may have different encoding/fidelity because the lossy roundtrip is removed. Query escaping preserves original text rather than accepting pre-encoded messages.

Legacy iOS `shareSingle` array replies are intentionally preserved: this does **not** duplicate #1770's response-shape migration. Launch/menu presentation is not proof of content delivery. The legacy Google+ route is retained for API compatibility, not presented as a restored service.

## Test plan

165 standalone actual Objective-C/Objective-C++ source controls pass on this isolated patch: files 11, module/picker 23, URL adapters 34, email/SMS 20, Instagram 16, Stories 29, WhatsApp 23 and generic composer 9. Foundation/UTType/file operations are real; UIKit, Photos and target apps are controlled doubles.

Combined unsigned arm64 iOS Simulator Debug builds pass. The RN 0.72 example requires an invocation-only `-Wno-error=deprecated-literal-operator` for old Yoga under current Xcode; no compatibility workaround is committed. Real Photos permission UI, social-app delivery, document delegate ordering on devices and signed release builds remain unverified. No checked-in test/spec files were added or changed. Standalone diagnostics use actual source; OS/framework doubles are identified below. Physical-device social-app delivery and manual screen-reader verification are not claimed.

Based on `a2d1594c58fbe2e2cea5a4aae4f65ee71dc77630`; metadata precedence is a separate PR.


## Downstream verification

The combined reviewed runtime fixes are adopted in our React Native 0.87.1 app through immutable 12.3.1-based artifact `a2af29ba70fa3cdb23c231b0de5e0de148cb9bbf` (source backport `c25ac3400f7cd721eba6cfcce6c6630e788237d1`). This artifact combines the runtime PRs; it is not an isolated test of only this PR. Package contents and generated entrypoints were checked against the installed artifact.

Immutable install, CocoaPods, app ESLint, 13 production web targets, all browser-extension builds, both Trackstats/Socialstats Android Debug builds, both unsigned arm64 iOS Simulator Debug builds and four separate production Metro bundles pass. Simulator builds use `SKIP_BUNDLING=1`; bundling was verified separately. Existing build/peer warnings remain. No physical-device delivery, signed release or deployment claim.
