### PR TITLE
fix(ios): preserve explicit share metadata and null activity defaults

### DIFF
--- a/ios/RNShareActivityItemSource.m
+++ b/ios/RNShareActivityItemSource.m
@@ -28,6 +28,10 @@
     if (self) {
         fetchCompletion = completion;
         placeholderItem = [RNShareActivityItemSource itemFromDictionary:options[@"placeholderItem"]];
+        itemDictionary = options[@"item"];
+        subjectDictionary = options[@"subject"];
+        dataTypeIdentifierDictionary = options[@"dataTypeIdentifier"];
+        thumbnailImageDictionary = options[@"thumbnailImage"];
 
 #ifdef __IPHONE_13_0
         if (@available(iOS 13.0, *)) {
@@ -45,10 +49,6 @@
         [self _invokeAndClearCompletion];
 #endif
 
-        itemDictionary = options[@"item"];
-        subjectDictionary = options[@"subject"];
-        dataTypeIdentifierDictionary = options[@"dataTypeIdentifier"];
-        thumbnailImageDictionary = options[@"thumbnailImage"];
     }
     return self;
 }
@@ -62,19 +62,27 @@
                 if (!self->linkMetadata) {
                     self->linkMetadata = metadata;
                 } else {
-                    self->linkMetadata.originalURL = metadata.originalURL;
-                    self->linkMetadata.URL = metadata.URL;
+                    if (!self->linkMetadata.originalURL) {
+                        self->linkMetadata.originalURL = metadata.originalURL;
+                    }
+                    if (!self->linkMetadata.URL) {
+                        self->linkMetadata.URL = metadata.URL;
+                    }
                     if(!self->linkMetadata.title) {
                         self->linkMetadata.title = metadata.title;
                     }
-                    self->linkMetadata.imageProvider = metadata.imageProvider;
-                    if (self->linkMetadata.imageProvider) {
-                        self->linkMetadata.iconProvider = self->linkMetadata.imageProvider;
-                    } else {
-                        self->linkMetadata.iconProvider = metadata.iconProvider;
+                    if (!self->linkMetadata.imageProvider) {
+                        self->linkMetadata.imageProvider = metadata.imageProvider;
                     }
-                    self->linkMetadata.remoteVideoURL = metadata.remoteVideoURL;
-                    self->linkMetadata.videoProvider = metadata.videoProvider;
+                    if (!self->linkMetadata.iconProvider) {
+                        self->linkMetadata.iconProvider = self->linkMetadata.imageProvider ?: metadata.iconProvider;
+                    }
+                    if (!self->linkMetadata.remoteVideoURL) {
+                        self->linkMetadata.remoteVideoURL = metadata.remoteVideoURL;
+                    }
+                    if (!self->linkMetadata.videoProvider) {
+                        self->linkMetadata.videoProvider = metadata.videoProvider;
+                    }
                 }
             }
             dispatch_async(dispatch_get_main_queue(), ^{
@@ -87,8 +95,9 @@
 
 - (void)_invokeAndClearCompletion {
     if (fetchCompletion) {
-        fetchCompletion();
+        void (^completion)(void) = fetchCompletion;
         fetchCompletion = nil;
+        completion();
     }
 }
 
@@ -285,7 +294,8 @@
             return obj;
         }
     }
-    return [dictionary objectForKey:@"default"];
+    id fallback = [dictionary objectForKey:@"default"];
+    return fallback == [NSNull null] ? nil : fallback;
 }
 
 #pragma mark - UIActivityItemSource


### PR DESCRIPTION
## Fixes and compatibility

- Preserve explicitly supplied URL/title/icon/image/video metadata; asynchronous fetched metadata fills only missing fields.
- Initialize source fields before a metadata provider can complete synchronously.
- Clear the completion handler before invoking it to avoid reentrant/duplicate completion.
- Convert an explicit JSON-null activity default to native nil instead of handing NSNull to UIKit.

**Behavior change:** custom metadata now wins over fetched metadata. Consumers relying on fetched values replacing their explicit options should omit those options. No public signatures change.

## Test plan

14 standalone actual-source checks pass on the independent patch; nine fail on baseline. Includes late provider results, explicit fields, null defaults, synchronous completion and reentrancy. Foundation is real; UIKit/LinkPresentation are doubles. Combined unsigned iOS Simulator build passes. No checked-in test/spec files were added or changed. Standalone diagnostics use actual source; OS/framework doubles are identified below. Physical-device social-app delivery and manual screen-reader verification are not claimed.

Based on `a2d1594c58fbe2e2cea5a4aae4f65ee71dc77630`.


## Downstream verification

The combined reviewed runtime fixes are adopted in our React Native 0.87.1 app through immutable 12.3.1-based artifact `a2af29ba70fa3cdb23c231b0de5e0de148cb9bbf` (source backport `c25ac3400f7cd721eba6cfcce6c6630e788237d1`). This artifact combines the runtime PRs; it is not an isolated test of only this PR. Package contents and generated entrypoints were checked against the installed artifact.

Immutable install, CocoaPods, app ESLint, 13 production web targets, all browser-extension builds, both Trackstats/Socialstats Android Debug builds, both unsigned arm64 iOS Simulator Debug builds and four separate production Metro bundles pass. Simulator builds use `SKIP_BUNDLING=1`; bundling was verified separately. Existing build/peer warnings remain. No physical-device delivery, signed release or deployment claim.
