### PR TITLE
fix(android): restore internal file sharing

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -63,6 +63,8 @@ repositories {
 }
 
 dependencies {
+    testImplementation 'junit:junit:4.13.2'
+
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
 }

--- a/android/src/main/res/xml/share_download_paths.xml
+++ b/android/src/main/res/xml/share_download_paths.xml
@@ -2,4 +2,5 @@
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <external-path name="rnshare1" path="Download/" />
     <cache-path name="rnshare2" path="/" />
+    <files-path name="rnshare_files" path="." />
 </paths>

--- a/android/src/test/java/cl/json/FileProviderPathsTest.java
+++ b/android/src/test/java/cl/json/FileProviderPathsTest.java
@@ -1,0 +1,36 @@
+package cl.json;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+public class FileProviderPathsTest {
+    private Document paths;
+
+    @Before
+    public void readPaths() throws Exception {
+        paths = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(
+                new File("src/main/res/xml/share_download_paths.xml"));
+    }
+
+    @Test
+    public void includesAppInternalFilesDirectory() {
+        assertEquals(1, paths.getElementsByTagName("files-path").getLength());
+        Element filesPath = (Element) paths.getElementsByTagName("files-path").item(0);
+
+        assertEquals("rnshare_files", filesPath.getAttribute("name"));
+        assertEquals(".", filesPath.getAttribute("path"));
+    }
+
+    @Test
+    public void doesNotExposeRootPath() {
+        assertEquals(0, paths.getElementsByTagName("root-path").getLength());
+    }
+}


### PR DESCRIPTION
# Overview

Fixes #1706.

Version 12.1.1 removed the broad `<root-path>` entry from the Android `FileProvider` configuration for security. That also removed coverage for files under `Context.getFilesDir()`, so sharing paths such as `file:///data/user/0/<application>/files/...` no longer produced a content URI and multi-file shares could crash before the chooser opened.

This change adds a scoped `<files-path>` entry for the application internal files directory. It does not restore `<root-path>` or access to the filesystem root. Regression tests require the internal-files mapping and also require `root-path` to remain absent.

# Test Plan

- `yarn validate`
- `yarn prepare`
- `./gradlew :react-native-share:testDebugUnitTest -PhermesEnabled=false --no-daemon` — 2 tests passed
- `./gradlew :app:assembleDebug -PhermesEnabled=false --no-daemon` — example APK built successfully

The Android commands used Java 17 and a local-only override to an already-installed NDK 26.1; that environment override is not part of this PR.